### PR TITLE
[fortress] Fix triggered camera test

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -315,6 +315,8 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
     this->dataPtr->node.Subscribe(this->dataPtr->triggerTopic,
         &CameraSensorPrivate::OnTrigger, this->dataPtr.get());
 
+    igndbg << "Camera trigger messages for [" << this->Name() << "] subscribed"
+           << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
     this->dataPtr->isTriggeredCamera = true;
   }
 

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -50,7 +50,7 @@
 
 using namespace std::chrono_literals;
 
-class CameraSensorTest: public testing::Test,
+class TriggeredCameraTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
   // Documentation inherited
@@ -63,7 +63,7 @@ class CameraSensorTest: public testing::Test,
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 };
 
-void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
+void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 {
   std::string path = ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test",
       "sdf", "triggered_camera_sensor_builtin.sdf");
@@ -159,12 +159,12 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, ImagesWithBuiltinSDF)
+TEST_P(TriggeredCameraTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
 }
 
-INSTANTIATE_TEST_CASE_P(CameraSensor, CameraSensorTest,
+INSTANTIATE_TEST_CASE_P(CameraSensor, TriggeredCameraTest,
     RENDER_ENGINE_VALUES, ignition::rendering::PrintToStringParam());
 
 //////////////////////////////////////////////////

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -111,7 +111,7 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
         "/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF";
     WaitForMessageTestHelper<ignition::msgs::Image> helper(imageTopic);
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
-    EXPECT_FALSE(helper.WaitForMessage(3s)) << helper;
+    EXPECT_FALSE(helper.WaitForMessage(1s)) << helper;
   }
 
   // trigger camera through topic

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -78,14 +78,6 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   ASSERT_TRUE(linkPtr->HasElement("sensor"));
   auto sensorPtr = linkPtr->GetElement("sensor");
 
-  // If ogre is not the engine, don't run the test
-  if (_renderEngine.compare("ogre") != 0)
-  {
-    igndbg << "Engine '" << _renderEngine
-      << "' doesn't support segmentation cameras" << std::endl;
-    return;
-  }
-
   // Setup ign-rendering with an empty scene
   auto *engine = ignition::rendering::engine(_renderEngine);
   if (!engine)

--- a/test/sdf/triggered_camera_sensor_builtin.sdf
+++ b/test/sdf/triggered_camera_sensor_builtin.sdf
@@ -7,6 +7,7 @@
         <topic>/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF</topic>
         <camera>
           <triggered>true</triggered>
+          <trigger_topic>/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF/trigger</trigger_topic>
           <horizontal_fov>1.05</horizontal_fov>
           <image>
             <width>256</width>


### PR DESCRIPTION
# 🦟 Bug fix

Starts to fix a broken test for triggered cameras

## Summary

A test for triggered cameras was added in #194, but it has a few issues.

* It's gtest class name is a duplicate of that from `test/integration/camera.cc`, so change it to `TriggeredCameraTest`
* The test was also being skipped on Ubuntu (which uses ogre2 for testing) due to an irrelevant requirement related to segmentation camera sensors.
* 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
