### PR TITLE
Add support for single channel 8 bit grayscale image format

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -214,6 +214,9 @@ bool CameraSensor::CreateCamera()
     case sdf::PixelFormatType::RGB_INT8:
       this->dataPtr->camera->SetImageFormat(ignition::rendering::PF_R8G8B8);
       break;
+    case sdf::PixelFormatType::L_INT8:
+      this->dataPtr->camera->SetImageFormat(ignition::rendering::PF_L8);
+      break;
     default:
       ignerr << "Unsupported pixel format ["
         << static_cast<int>(pixelFormat) << "]\n";
@@ -434,6 +437,10 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
     case ignition::rendering::PF_R8G8B8:
       format = ignition::common::Image::RGB_INT8;
       msgsPixelFormat = msgs::PixelFormatType::RGB_INT8;
+      break;
+    case ignition::rendering::PF_L8:
+      format = ignition::common::Image::L_INT8;
+      msgsPixelFormat = msgs::PixelFormatType::L_INT8;
       break;
     default:
       ignerr << "Unsupported pixel format ["

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -48,6 +48,18 @@
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
+std::mutex g_mutex;
+unsigned int g_imgCounter = 0;
+
+void OnGrayscaleImage(const ignition::msgs::Image &_msg)
+{
+  std::lock_guard<std::mutex> lock(g_mutex);
+  EXPECT_EQ(ignition::msgs::PixelFormatType::L_INT8, _msg.pixel_format_type());
+  EXPECT_EQ(256u, _msg.width());
+  EXPECT_EQ(256u, _msg.height());
+  g_imgCounter++;
+}
+
 class CameraSensorTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
@@ -59,6 +71,9 @@ class CameraSensorTest: public testing::Test,
 
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+
+  // Create a 8 bit grayscale camera sensor and verify image format
+  public: void ImageFormatLInt8(const std::string &_renderEngine);
 };
 
 void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
@@ -148,6 +163,96 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 TEST_P(CameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
+}
+
+//////////////////////////////////////////////////
+void CameraSensorTest::ImageFormatLInt8(const std::string &_renderEngine)
+{
+  // get the darn test data
+  std::string path = ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "camera_sensor_l8_builtin.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+  // Setup ign-rendering with an empty scene
+  auto *engine = ignition::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ignition::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  // do the test
+  ignition::sensors::Manager mgr;
+
+  ignition::sensors::CameraSensor *sensor =
+      mgr.CreateSensor<ignition::sensors::CameraSensor>(sensorPtr);
+  ASSERT_NE(sensor, nullptr);
+  sensor->SetScene(scene);
+
+  ASSERT_NE(sensor->RenderingCamera(), nullptr);
+  EXPECT_NE(sensor->Id(), sensor->RenderingCamera()->Id());
+  EXPECT_EQ(256u, sensor->ImageWidth());
+  EXPECT_EQ(256u, sensor->ImageHeight());
+
+  std::string topic = "/images_l8";
+  WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+
+  // Update once to create image
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+
+  EXPECT_TRUE(helper.WaitForMessage()) << helper;
+
+  // subscribe to the camera topic
+  ignition::transport::Node node;
+  node.Subscribe(topic, &OnGrayscaleImage);
+
+  // wait for a few camera frames
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+
+  // run to get image and check image format in callback
+  bool done = false;
+  int sleep = 0;
+  int maxSleep = 10;
+  while (!done && sleep++ < maxSleep)
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    done = (g_imgCounter > 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  // test removing sensor
+  // first make sure the sensor objects do exist
+  auto sensorId = sensor->Id();
+  auto cameraId = sensor->RenderingCamera()->Id();
+  EXPECT_EQ(sensor, mgr.Sensor(sensorId));
+  EXPECT_EQ(sensor->RenderingCamera(), scene->SensorById(cameraId));
+  // remove and check sensor objects no longer exist in both sensors and
+  // rendering
+  EXPECT_TRUE(mgr.Remove(sensorId));
+  EXPECT_EQ(nullptr, mgr.Sensor(sensorId));
+  EXPECT_EQ(nullptr, scene->SensorById(cameraId));
+
+  // Clean up
+  engine->DestroyScene(scene);
+  ignition::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(CameraSensorTest, LInt8ImagesWithBuiltinSDF)
+{
+  ImageFormatLInt8(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(CameraSensor, CameraSensorTest,

--- a/test/sdf/camera_sensor_l8_builtin.sdf
+++ b/test/sdf/camera_sensor_l8_builtin.sdf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera1" type="camera">
+        <update_rate>10</update_rate>
+        <ignition_frame_id>base_camera</ignition_frame_id>
+        <topic>/images_l8</topic>
+        <camera>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>256</width>
+            <height>256</height>
+            <format>L8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>
# 🎉 New feature

## Summary

Add support for 8 bit grayscale format: `L_INT8` or `L8`

## Test it

Run the `camera` integration test.

You can also test with ign-gazebo.

1. Add `<format>L8</format>` to the `sensors_demo.sdf` world [here](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo6/examples/worlds/sensors_demo.sdf#L381)

1. Launch ign-gazebo with the updated world to see that the top left image display now displays grayscale images

![grayscale_image_format](https://user-images.githubusercontent.com/4000684/164563750-a87be2ab-b52c-4a76-b1bb-3f4bd99aefa5.png)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

