### PR TITLE
Add HasConnections function

### DIFF
--- a/include/ignition/sensors/AirPressureSensor.hh
+++ b/include/ignition/sensors/AirPressureSensor.hh
@@ -80,7 +80,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: bool HasConnections() const;
+      public: virtual bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/AirPressureSensor.hh
+++ b/include/ignition/sensors/AirPressureSensor.hh
@@ -78,6 +78,10 @@ namespace ignition
       /// \return Verical reference position in meters
       public: double ReferenceAltitude() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/AirPressureSensor.hh
+++ b/include/ignition/sensors/AirPressureSensor.hh
@@ -80,7 +80,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/AltimeterSensor.hh
+++ b/include/ignition/sensors/AltimeterSensor.hh
@@ -97,7 +97,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/AltimeterSensor.hh
+++ b/include/ignition/sensors/AltimeterSensor.hh
@@ -95,6 +95,10 @@ namespace ignition
       /// \return Vertical velocity in meters per second
       public: double VerticalVelocity() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/CameraSensor.hh
+++ b/include/ignition/sensors/CameraSensor.hh
@@ -138,6 +138,10 @@ namespace ignition
       /// \return The distance from the 1st camera, in meters.
       public: double Baseline() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       /// \brief Advertise camera info topic.
       /// \return True if successful.
       protected: bool AdvertiseInfo();

--- a/include/ignition/sensors/CameraSensor.hh
+++ b/include/ignition/sensors/CameraSensor.hh
@@ -140,7 +140,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Advertise camera info topic.
       /// \return True if successful.

--- a/include/ignition/sensors/DepthCameraSensor.hh
+++ b/include/ignition/sensors/DepthCameraSensor.hh
@@ -157,6 +157,9 @@ namespace ignition
       /// \return height of the image
       public: virtual double NearClip() const;
 
+      // Documentation inherited
+      public: virtual bool HasConnections() const override;
+
       /// \brief Create a camera in a scene
       /// \return True on success.
       private: bool CreateCamera();

--- a/include/ignition/sensors/DepthCameraSensor.hh
+++ b/include/ignition/sensors/DepthCameraSensor.hh
@@ -159,7 +159,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Create a camera in a scene
       /// \return True on success.

--- a/include/ignition/sensors/DepthCameraSensor.hh
+++ b/include/ignition/sensors/DepthCameraSensor.hh
@@ -157,8 +157,9 @@ namespace ignition
       /// \return height of the image
       public: virtual double NearClip() const;
 
-      // Documentation inherited
-      public: virtual bool HasConnections() const override;
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
 
       /// \brief Create a camera in a scene
       /// \return True on success.

--- a/include/ignition/sensors/ForceTorqueSensor.hh
+++ b/include/ignition/sensors/ForceTorqueSensor.hh
@@ -114,6 +114,10 @@ namespace ignition
       public: void SetRotationChildInSensor(
                   const math::Quaterniond &_rotChildInSensor);
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/ForceTorqueSensor.hh
+++ b/include/ignition/sensors/ForceTorqueSensor.hh
@@ -116,7 +116,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -138,7 +138,6 @@ namespace ignition
                   unsigned int _heighti, unsigned int _channels,
                   const std::string &_format);
 
-
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -121,8 +121,9 @@ namespace ignition
       /// \return Vertical field of view.
       public: ignition::math::Angle VFOV() const;
 
-      // Documentation inherited
-      public: virtual bool HasConnections() const override;
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: bool HasConnections() const;
 
       /// \brief Connect function pointer to internal GpuRays callback
       /// \return ignition::common::Connection pointer

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -121,6 +121,9 @@ namespace ignition
       /// \return Vertical field of view.
       public: ignition::math::Angle VFOV() const;
 
+      // Documentation inherited
+      public: virtual bool HasConnections() const override;
+
       /// \brief Connect function pointer to internal GpuRays callback
       /// \return ignition::common::Connection pointer
       public: virtual ignition::common::ConnectionPtr ConnectNewLidarFrame(

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -132,6 +132,13 @@ namespace ignition
                   unsigned int _heighti, unsigned int _channels,
                   const std::string &/*_format*/)> _subscriber) override;
 
+      /// \brief Connect function pointer to internal GpuRays callback
+      /// \return ignition::common::Connection pointer
+      private: void OnNewLidarFrame(const float *_scan, unsigned int _width,
+                  unsigned int _heighti, unsigned int _channels,
+                  const std::string &_format);
+
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -164,6 +164,10 @@ namespace ignition
       public: void SetWorldFrameOrientation(
         const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo);
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -166,7 +166,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -166,7 +166,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: bool HasConnections() const;
+      public: virtual bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -238,7 +238,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers for sensor data
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Just a mutex for thread safety

--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -236,6 +236,10 @@ namespace ignition
       // Documentation inherited
       public: virtual bool IsActive() const;
 
+      /// \brief Check if there are any subscribers for sensor data
+      /// \return True if there are subscribers, false otherwise
+      public: bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Just a mutex for thread safety
       public: mutable std::mutex lidarMutex;

--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -238,7 +238,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers for sensor data
       /// \return True if there are subscribers, false otherwise
-      public: bool HasConnections() const;
+      public: virtual bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Just a mutex for thread safety

--- a/include/ignition/sensors/LogicalCameraSensor.hh
+++ b/include/ignition/sensors/LogicalCameraSensor.hh
@@ -106,6 +106,10 @@ namespace ignition
       /// \return The frustum's aspect ratio.
       public: double AspectRatio() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       /// \brief Get the latest image. An image is an instance of
       /// msgs::LogicalCameraImage, which contains a list of detected models.
       /// \return List of detected models.

--- a/include/ignition/sensors/LogicalCameraSensor.hh
+++ b/include/ignition/sensors/LogicalCameraSensor.hh
@@ -108,7 +108,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Get the latest image. An image is an instance of
       /// msgs::LogicalCameraImage, which contains a list of detected models.

--- a/include/ignition/sensors/MagnetometerSensor.hh
+++ b/include/ignition/sensors/MagnetometerSensor.hh
@@ -93,7 +93,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: bool HasConnections() const;
+      public: virtual bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/MagnetometerSensor.hh
+++ b/include/ignition/sensors/MagnetometerSensor.hh
@@ -91,6 +91,10 @@ namespace ignition
       /// \return Magnetic field vector in body frame
       public: math::Vector3d MagneticField() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/MagnetometerSensor.hh
+++ b/include/ignition/sensors/MagnetometerSensor.hh
@@ -93,7 +93,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/NavSatSensor.hh
+++ b/include/ignition/sensors/NavSatSensor.hh
@@ -110,7 +110,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Easy short hand for setting the position of the sensor.
       /// \param[in] _latitude Latitude angle.

--- a/include/ignition/sensors/NavSatSensor.hh
+++ b/include/ignition/sensors/NavSatSensor.hh
@@ -108,6 +108,10 @@ namespace ignition
       /// \return Velocity in meters per second
       public: const math::Vector3d &Velocity() const;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       /// \brief Easy short hand for setting the position of the sensor.
       /// \param[in] _latitude Latitude angle.
       /// \param[in] _longitude Longitude angle.

--- a/include/ignition/sensors/RenderingSensor.hh
+++ b/include/ignition/sensors/RenderingSensor.hh
@@ -92,6 +92,20 @@ namespace ignition
       private: std::unique_ptr<RenderingSensorPrivate> dataPtr;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
+
+    /// \internal
+    /// \brief Extension class for rendering sensors
+    /// Function are added here to preserve ABI compatibility of rendering
+    /// sensor classes
+    class RenderingSensorExt : public SensorExt
+    {
+      /// \brief Constructor
+      public: RenderingSensorExt(Sensor *_sensor);
+
+      // Documentation inherited
+      public: virtual bool HasConnections() const override;
+    };
+
     }
   }
 }

--- a/include/ignition/sensors/RenderingSensor.hh
+++ b/include/ignition/sensors/RenderingSensor.hh
@@ -92,20 +92,6 @@ namespace ignition
       private: std::unique_ptr<RenderingSensorPrivate> dataPtr;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
-
-    /// \internal
-    /// \brief Extension class for rendering sensors
-    /// Function are added here to preserve ABI compatibility of rendering
-    /// sensor classes
-    class RenderingSensorExt : public SensorExt
-    {
-      /// \brief Constructor
-      public: RenderingSensorExt(Sensor *_sensor);
-
-      // Documentation inherited
-      public: virtual bool HasConnections() const override;
-    };
-
     }
   }
 }

--- a/include/ignition/sensors/RgbdCameraSensor.hh
+++ b/include/ignition/sensors/RgbdCameraSensor.hh
@@ -92,7 +92,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Create an RGB camera and a depth camera.
       /// \return True on success.

--- a/include/ignition/sensors/RgbdCameraSensor.hh
+++ b/include/ignition/sensors/RgbdCameraSensor.hh
@@ -90,6 +90,10 @@ namespace ignition
       /// \return height of the image
       public: virtual unsigned int ImageHeight() const override;
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       /// \brief Create an RGB camera and a depth camera.
       /// \return True on success.
       private: bool CreateCameras();

--- a/include/ignition/sensors/SegmentationCameraSensor.hh
+++ b/include/ignition/sensors/SegmentationCameraSensor.hh
@@ -119,7 +119,11 @@ namespace ignition
       /// \return height of the image
       public: virtual unsigned int ImageHeight() const override;
 
-     /// \brief Create a camera in a scene
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
+      /// \brief Create a camera in a scene
       /// \return True on success.
       private: bool CreateCamera();
 

--- a/include/ignition/sensors/SegmentationCameraSensor.hh
+++ b/include/ignition/sensors/SegmentationCameraSensor.hh
@@ -121,7 +121,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Create a camera in a scene
       /// \return True on success.

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -220,6 +220,10 @@ namespace ignition
       /// \sa IsActive
       public: void SetActive(bool _active);
 
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -220,12 +220,6 @@ namespace ignition
       /// \sa IsActive
       public: void SetActive(bool _active);
 
-      /// \brief Check if there are any subscribers
-      /// \return True if there are subscribers, false otherwise
-      /// \todo(iche033) make this virtual class and let all derived sensor classes
-      /// override this function
-      public: bool HasConnections() const;
-
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -50,7 +50,6 @@ namespace ignition
 
     /// \brief forward declarations
     class SensorPrivate;
-    class SensorExt;
 
     /// \brief a base sensor class
     ///
@@ -227,39 +226,11 @@ namespace ignition
       /// override this function
       public: bool HasConnections() const;
 
-      /// \internal
-      /// \brief Set sensor extension. The extension class consts of
-      /// functions/features that could not be added to the core Sensor class
-      /// for ABI compatibility reason. For internal use only
-      /// \param[in] _ext Extension class
-      protected: void SetExtension(const std::shared_ptr<SensorExt> &_ext);
-
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data
       private: std::unique_ptr<SensorPrivate> dataPtr;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
-    };
-
-    /// \internal
-    /// \brief Extension class for sensor
-    /// Function are added here to preserve ABI compatibility of the base
-    /// sensor class
-    class SensorExt
-    {
-      /// \brief Constructor
-      /// \param[in] _sensor Pointer to parent sensor
-      public: SensorExt(Sensor *_sensor);
-
-      /// \brief Destructor
-      public: virtual ~SensorExt() = default;
-
-      /// \brief Check if there are any subscribers
-      /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
-
-      /// \brief Pointer to parent sensor
-      protected: Sensor *sensor = nullptr;
     };
     }
   }

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -50,6 +50,7 @@ namespace ignition
 
     /// \brief forward declarations
     class SensorPrivate;
+    class SensorExt;
 
     /// \brief a base sensor class
     ///
@@ -222,13 +223,43 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      /// \todo(iche033) make this virtual class and let all derived sensor classes
+      /// override this function
+      public: bool HasConnections() const;
+
+      /// \internal
+      /// \brief Set sensor extension. The extension class consts of
+      /// functions/features that could not be added to the core Sensor class
+      /// for ABI compatibility reason. For internal use only
+      /// \param[in] _ext Extension class
+      protected: void SetExtension(const std::shared_ptr<SensorExt> &_ext);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data
       private: std::unique_ptr<SensorPrivate> dataPtr;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+    };
+
+    /// \internal
+    /// \brief Extension class for sensor
+    /// Function are added here to preserve ABI compatibility of the base
+    /// sensor class
+    class SensorExt
+    {
+      /// \brief Constructor
+      /// \param[in] _sensor Pointer to parent sensor
+      public: SensorExt(Sensor *_sensor);
+
+      /// \brief Destructor
+      public: virtual ~SensorExt() = default;
+
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
+      /// \brief Pointer to parent sensor
+      protected: Sensor *sensor = nullptr;
     };
     }
   }

--- a/include/ignition/sensors/ThermalCameraSensor.hh
+++ b/include/ignition/sensors/ThermalCameraSensor.hh
@@ -163,7 +163,7 @@ namespace ignition
 
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
-      public: virtual bool HasConnections() const;
+      public: bool HasConnections() const;
 
       /// \brief Create a camera in a scene
       /// \return True on success.

--- a/include/ignition/sensors/ThermalCameraSensor.hh
+++ b/include/ignition/sensors/ThermalCameraSensor.hh
@@ -161,7 +161,11 @@ namespace ignition
       /// \param[in] resolution Temperature linear resolution
       public: virtual void SetLinearResolution(float _resolution);
 
-     /// \brief Create a camera in a scene
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const;
+
+      /// \brief Create a camera in a scene
       /// \return True on success.
       private: bool CreateCamera();
 

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -220,3 +220,8 @@ double AirPressureSensor::ReferenceAltitude() const
   return this->dataPtr->referenceAltitude;
 }
 
+//////////////////////////////////////////////////
+bool AirPressureSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -215,3 +215,8 @@ double AltimeterSensor::VerticalVelocity() const
   return this->dataPtr->verticalVelocity;
 }
 
+//////////////////////////////////////////////////
+bool AltimeterSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -697,3 +697,9 @@ double CameraSensor::Baseline() const
   return this->dataPtr->baseline;
 }
 
+//////////////////////////////////////////////////
+bool CameraSensor::HasConnections() const
+{
+  return (this->dataPtr->pub && this->dataPtr->pub.HasConnections()) ||
+      this->dataPtr->imageEvent.ConnectionCount() > 0u;
+}

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -655,7 +655,7 @@ double DepthCameraSensor::NearClip() const
 //////////////////////////////////////////////////
 bool DepthCameraSensor::HasConnections() const
 {
-  return this->dataPtr->pub.HasConnections() ||
-      this->dataPtr->imageEvent.ConnectionCount() > 0u ||
-      this->dataPtr->pointPub.HasConnections();
+  return (this->dataPtr->pub && this->dataPtr->pub.HasConnections()) ||
+      (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections()) ||
+      this->dataPtr->imageEvent.ConnectionCount() > 0u;
 }

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -527,6 +527,15 @@ bool DepthCameraSensor::Update(
     return false;
   }
 
+
+  // Don't do any work if no one is requesting data
+//  if (!this->dataPtr->pub.HasConnections()
+//      this->dataPtr->imageEvent.ConnectionCount() == 0u &&
+//      !this->dataPtr->pointPub.HasConnections())
+//  {
+//    return false;
+//  }
+
   // generate sensor data
   this->Render();
 
@@ -536,37 +545,48 @@ bool DepthCameraSensor::Update(
   auto msgsFormat = msgs::PixelFormatType::R_FLOAT32;
 
   // create message
-  ignition::msgs::Image msg;
-  msg.set_width(width);
-  msg.set_height(height);
-  msg.set_step(width * rendering::PixelUtil::BytesPerPixel(
-               rendering::PF_FLOAT32_R));
-  msg.set_pixel_format_type(msgsFormat);
-  *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
-  auto frame = msg.mutable_header()->add_data();
-  frame->set_key("frame_id");
-  frame->add_value(this->FrameId());
 
-  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  msg.set_data(this->dataPtr->depthBuffer,
-      rendering::PixelUtil::MemorySize(rendering::PF_FLOAT32_R,
-      width, height));
-
-  // publish
-  this->AddSequence(msg.mutable_header(), "default");
-  this->dataPtr->pub.Publish(msg);
-
-  // publish the camera info message
-  this->PublishInfo(_now);
-
-  // Trigger callbacks.
-  try
+//  if (this->dataPtr->pub.HasConnections() ||
+//      this->dataPtr->imageEvent.ConnectionCount() >  0u)
   {
-    this->dataPtr->imageEvent(msg);
-  }
-  catch(...)
-  {
-    ignerr << "Exception thrown in an image callback.\n";
+    ignition::msgs::Image msg;
+    msg.set_width(width);
+    msg.set_height(height);
+    msg.set_step(width * rendering::PixelUtil::BytesPerPixel(
+                 rendering::PF_FLOAT32_R));
+    msg.set_pixel_format_type(msgsFormat);
+    *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
+    auto frame = msg.mutable_header()->add_data();
+    frame->set_key("frame_id");
+    frame->add_value(this->FrameId());
+
+    std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+    msg.set_data(this->dataPtr->depthBuffer,
+        rendering::PixelUtil::MemorySize(rendering::PF_FLOAT32_R,
+        width, height));
+
+    // publish
+//    if (this->dataPtr->pub.HasConnections())
+    {
+      this->AddSequence(msg.mutable_header(), "default");
+      this->dataPtr->pub.Publish(msg);
+
+      // publish the camera info message
+      this->PublishInfo(_now);
+    }
+
+//    if (this->dataPtr->imageEvent.ConnectionCount() > 0u)
+    {
+      // Trigger callbacks.
+      try
+      {
+        this->dataPtr->imageEvent(msg);
+      }
+      catch(...)
+      {
+        ignerr << "Exception thrown in an image callback.\n";
+      }
+    }
   }
 
   if (this->dataPtr->pointPub.HasConnections() &&
@@ -632,3 +652,10 @@ double DepthCameraSensor::NearClip() const
   return this->dataPtr->near;
 }
 
+//////////////////////////////////////////////////
+bool DepthCameraSensor::HasConnections() const
+{
+  return this->dataPtr->pub.HasConnections() ||
+      this->dataPtr->imageEvent.ConnectionCount() > 0u ||
+      this->dataPtr->pointPub.HasConnections();
+}

--- a/src/ForceTorqueSensor.cc
+++ b/src/ForceTorqueSensor.cc
@@ -312,3 +312,9 @@ math::Quaterniond ForceTorqueSensor::RotationChildInSensor() const
 {
   return math::Quaterniond(this->dataPtr->rotationChildInSensor);
 }
+
+//////////////////////////////////////////////////
+bool ForceTorqueSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -48,6 +48,21 @@ class ignition::sensors::GpuLidarSensorPrivate
   /// \brief Connection to the Manager's scene change event.
   public: ignition::common::ConnectionPtr sceneChangeConnection;
 
+  /// \brief Event that is used to trigger callbacks when a new
+  /// lidar frame is available
+  public: ignition::common::EventT<
+          void(const float *_scan, unsigned int _width,
+               unsigned int _height, unsigned int _channels,
+               const std::string &_format)> lidarEvent;
+
+  /// \brief Callback when new lidar frame is received
+  public: void OnNewLidarFrame(const float *_scan, unsigned int _width,
+               unsigned int _height, unsigned int _channels,
+               const std::string &_format);
+
+  /// \brief Connection to gpuRays new lidar frame event
+  public: ignition::common::ConnectionPtr lidarFrameConnection;
+
   /// \brief The point cloud message.
   public: msgs::PointCloudPacked pointMsg;
 
@@ -186,7 +201,7 @@ bool GpuLidarSensor::CreateLidar()
   this->dataPtr->gpuRays->SetNearClipPlane(this->RangeMin());
   this->dataPtr->gpuRays->SetFarClipPlane(this->RangeMax());
 
-  // Mask ranges outside of min/max to +/- inf, as per REP 117
+  // Make ranges outside of min/max to +/- inf, as per REP 117
   this->dataPtr->gpuRays->SetClamp(false);
 
   this->dataPtr->gpuRays->SetAngleMin(this->AngleMin().Radian());
@@ -212,10 +227,38 @@ bool GpuLidarSensor::CreateLidar()
       this->dataPtr->pointMsg.point_step() *
       this->dataPtr->pointMsg.width());
 
+  this->dataPtr->lidarFrameConnection =
+      this->dataPtr->gpuRays->ConnectNewGpuRaysFrame(
+      std::bind(&GpuLidarSensor::OnNewLidarFrame, this,
+      std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+      std::placeholders::_4, std::placeholders::_5));
+
   this->AddSensor(this->dataPtr->gpuRays);
 
   return true;
 }
+
+/////////////////////////////////////////////////
+void GpuLidarSensor::OnNewLidarFrame(const float *_data,
+    unsigned int _width, unsigned int _height, unsigned int _channels,
+    const std::string &_format)
+{
+  std::lock_guard<std::mutex> lock(this->lidarMutex);
+
+  unsigned int samples = _width * _height * _channels;
+  unsigned int lidarBufferSize = samples * sizeof(float);
+
+  if (!this->laserBuffer)
+    this->laserBuffer = new float[samples];
+
+  memcpy(this->laserBuffer, _data, lidarBufferSize);
+
+  if (this->dataPtr->lidarEvent.ConnectionCount() > 0)
+  {
+    this->dataPtr->lidarEvent(_data, _width, _height, _channels, _format);
+  }
+}
+
 
 //////////////////////////////////////////////////
 bool GpuLidarSensor::Update(const std::chrono::steady_clock::duration &_now)
@@ -233,18 +276,7 @@ bool GpuLidarSensor::Update(const std::chrono::steady_clock::duration &_now)
     return false;
   }
 
-  int len = this->dataPtr->gpuRays->RayCount() *
-    this->dataPtr->gpuRays->VerticalRayCount() * 3;
-
-  if (this->laserBuffer == nullptr)
-  {
-    this->laserBuffer = new float[len];
-  }
-
   this->Render();
-
-  /// \todo(anyone) It would be nice to remove this copy.
-  this->dataPtr->gpuRays->Copy(this->laserBuffer);
 
   // Apply noise before publishing the data.
   this->ApplyNoise();
@@ -287,7 +319,7 @@ ignition::common::ConnectionPtr GpuLidarSensor::ConnectNewLidarFrame(
                   unsigned int _height, unsigned int _channels,
                   const std::string &/*_format*/)> _subscriber)
 {
-  return this->dataPtr->gpuRays->ConnectNewGpuRaysFrame(_subscriber);
+  return this->dataPtr->lidarEvent.Connect(_subscriber);
 }
 
 /////////////////////////////////////////////////
@@ -318,7 +350,8 @@ ignition::math::Angle GpuLidarSensor::VFOV() const
 bool GpuLidarSensor::HasConnections() const
 {
   return Lidar::HasConnections() ||
-     (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections());
+     (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections()) ||
+     this->dataPtr->lidarEvent.ConnectionCount() > 0u;
 }
 
 //////////////////////////////////////////////////

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -315,6 +315,13 @@ ignition::math::Angle GpuLidarSensor::VFOV() const
 }
 
 //////////////////////////////////////////////////
+bool GpuLidarSensor::HasConnections() const
+{
+  return Lidar::HasConnections() ||
+     (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections());
+}
+
+//////////////////////////////////////////////////
 void GpuLidarSensorPrivate::FillPointCloudMsg(const float *_laserBuffer)
 {
   IGN_PROFILE("GpuLidarSensorPrivate::FillPointCloudMsg");
@@ -390,4 +397,3 @@ void GpuLidarSensorPrivate::FillPointCloudMsg(const float *_laserBuffer)
   }
   this->pointMsg.set_is_dense(isDense);
 }
-

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -201,7 +201,7 @@ bool GpuLidarSensor::CreateLidar()
   this->dataPtr->gpuRays->SetNearClipPlane(this->RangeMin());
   this->dataPtr->gpuRays->SetFarClipPlane(this->RangeMax());
 
-  // Make ranges outside of min/max to +/- inf, as per REP 117
+  // Mask ranges outside of min/max to +/- inf, as per REP 117
   this->dataPtr->gpuRays->SetClamp(false);
 
   this->dataPtr->gpuRays->SetAngleMin(this->AngleMin().Radian());
@@ -258,7 +258,6 @@ void GpuLidarSensor::OnNewLidarFrame(const float *_data,
     this->dataPtr->lidarEvent(_data, _width, _height, _channels, _format);
   }
 }
-
 
 //////////////////////////////////////////////////
 bool GpuLidarSensor::Update(const std::chrono::steady_clock::duration &_now)

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -427,4 +427,3 @@ bool ImuSensor::HasConnections() const
 {
   return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
 }
-

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -422,3 +422,9 @@ math::Quaterniond ImuSensor::Orientation() const
   return this->dataPtr->orientation;
 }
 
+//////////////////////////////////////////////////
+bool ImuSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}
+

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -455,3 +455,8 @@ bool Lidar::IsActive() const
   return true;
 }
 
+//////////////////////////////////////////////////
+bool Lidar::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -203,3 +203,9 @@ msgs::LogicalCameraImage LogicalCameraSensor::Image() const
   return this->dataPtr->msg;
 }
 
+//////////////////////////////////////////////////
+bool LogicalCameraSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}
+

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -234,3 +234,8 @@ math::Vector3d MagnetometerSensor::MagneticField() const
   return this->dataPtr->localField;
 }
 
+//////////////////////////////////////////////////
+bool MagnetometerSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/NavSatSensor.cc
+++ b/src/NavSatSensor.cc
@@ -260,3 +260,9 @@ void NavSatSensor::SetPosition(const math::Angle &_latitude,
   this->SetAltitude(_altitude);
 }
 
+//////////////////////////////////////////////////
+bool NavSatSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}
+

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -28,14 +28,6 @@
 #pragma warning(pop)
 #endif
 
-// \todo(iche033) Remove these includes when HasConnections() function
-// becomes virtual
-#include "ignition/sensors/CameraSensor.hh"
-#include "ignition/sensors/DepthCameraSensor.hh"
-#include "ignition/sensors/RgbdCameraSensor.hh"
-#include "ignition/sensors/SegmentationCameraSensor.hh"
-#include "ignition/sensors/ThermalCameraSensor.hh"
-
 #include "ignition/sensors/RenderingSensor.hh"
 
 /// \brief Private data class for RenderingSensor
@@ -50,10 +42,6 @@ class ignition::sensors::RenderingSensorPrivate
   /// \brief Pointer to the internal rendering sensors used for generating
   /// sensor data
   public: std::vector<rendering::SensorPtr::weak_type> sensors;
-
-  /// \brief Sensor class extention
-  /// \todo(iche033) remove once HasConnections() becomes virtual
-  public: std::shared_ptr<SensorExt> sensorExt;
 };
 
 using namespace ignition;
@@ -63,8 +51,6 @@ using namespace sensors;
 RenderingSensor::RenderingSensor() :
   dataPtr(new RenderingSensorPrivate)
 {
-  this->dataPtr->sensorExt = std::make_shared<SensorExt>(this);
-  this->SetExtension(this->dataPtr->sensorExt);
 }
 
 //////////////////////////////////////////////////
@@ -142,42 +128,4 @@ void RenderingSensor::Render()
     // called per sensor, so we don't have to do anything here
     this->dataPtr->scene->PostRender();
   }
-}
-
-/////////////////////////////////////////////////
-RenderingSensorExt::RenderingSensorExt(Sensor *_sensor)
-  : SensorExt(_sensor)
-{
-}
-
-/////////////////////////////////////////////////
-bool RenderingSensorExt::HasConnections() const
-{
-  // \todo(iche033) Remove this function when HasConnections() becomes virtual
-  {
-    auto s = dynamic_cast<const CameraSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const DepthCameraSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const GpuRaySensorSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const SegmentationCameraSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const ThermalCameraSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  return true;
 }

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -28,6 +28,14 @@
 #pragma warning(pop)
 #endif
 
+// \todo(iche033) Remove these includes when HasConnections() function
+// becomes virtual
+#include "ignition/sensors/CameraSensor.hh"
+#include "ignition/sensors/DepthCameraSensor.hh"
+#include "ignition/sensors/RgbdCameraSensor.hh"
+#include "ignition/sensors/SegmentationCameraSensor.hh"
+#include "ignition/sensors/ThermalCameraSensor.hh"
+
 #include "ignition/sensors/RenderingSensor.hh"
 
 /// \brief Private data class for RenderingSensor
@@ -42,6 +50,10 @@ class ignition::sensors::RenderingSensorPrivate
   /// \brief Pointer to the internal rendering sensors used for generating
   /// sensor data
   public: std::vector<rendering::SensorPtr::weak_type> sensors;
+
+  /// \brief Sensor class extention
+  /// \todo(iche033) remove once HasConnections() becomes virtual
+  public: std::shared_ptr<SensorExt> sensorExt;
 };
 
 using namespace ignition;
@@ -51,6 +63,8 @@ using namespace sensors;
 RenderingSensor::RenderingSensor() :
   dataPtr(new RenderingSensorPrivate)
 {
+  this->dataPtr->sensorExt = std::make_shared<SensorExt>(this);
+  this->SetExtension(this->dataPtr->sensorExt);
 }
 
 //////////////////////////////////////////////////
@@ -130,3 +144,40 @@ void RenderingSensor::Render()
   }
 }
 
+/////////////////////////////////////////////////
+RenderingSensorExt::RenderingSensorExt(Sensor *_sensor)
+  : SensorExt(_sensor)
+{
+}
+
+/////////////////////////////////////////////////
+bool RenderingSensorExt::HasConnections() const
+{
+  // \todo(iche033) Remove this function when HasConnections() becomes virtual
+  {
+    auto s = dynamic_cast<const CameraSensor *>(this->sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
+    auto s = dynamic_cast<const DepthCameraSensor *>(this->sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
+    auto s = dynamic_cast<const GpuRaySensorSensor *>(this->sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
+    auto s = dynamic_cast<const SegmentationCameraSensor *>(this->sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
+    auto s = dynamic_cast<const ThermalCameraSensor *>(this->sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  return true;
+}

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -623,7 +623,8 @@ unsigned int RgbdCameraSensor::ImageHeight() const
 //////////////////////////////////////////////////
 bool RgbdCameraSensor::HasConnections() const
 {
-  return (this->dataPtr->imagePub && this->dataPtr->imagePub.HasConnections()) ||
+  return (this->dataPtr->imagePub &&
+      this->dataPtr->imagePub.HasConnections()) ||
       (this->dataPtr->depthPub && this->dataPtr->depthPub.HasConnections()) ||
       (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections());
 }

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -620,3 +620,11 @@ unsigned int RgbdCameraSensor::ImageHeight() const
   return this->dataPtr->depthCamera->ImageHeight();
 }
 
+//////////////////////////////////////////////////
+bool RgbdCameraSensor::HasConnections() const
+{
+  return (this->dataPtr->imagePub && this->dataPtr->imagePub.HasConnections()) ||
+      (this->dataPtr->depthPub && this->dataPtr->depthPub.HasConnections()) ||
+      (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections());
+}
+

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -628,4 +628,3 @@ bool RgbdCameraSensor::HasConnections() const
       (this->dataPtr->depthPub && this->dataPtr->depthPub.HasConnections()) ||
       (this->dataPtr->pointPub && this->dataPtr->pointPub.HasConnections());
 }
-

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -554,6 +554,16 @@ common::ConnectionPtr SegmentationCameraSensor::ConnectImageCallback(
 }
 
 //////////////////////////////////////////////////
+bool SegmentationCameraSensor::HasConnections() const
+{
+  return (this->dataPtr->coloredMapPublisher &&
+      this->dataPtr->coloredMapPublisher.HasConnections()) ||
+      (this->dataPtr->labelsMapPublisher &&
+      this->dataPtr->labelsMapPublisher.HasConnections()) ||
+      this->dataPtr->imageEvent.ConnectionCount() > 0u;
+}
+
+//////////////////////////////////////////////////
 bool SegmentationCameraSensorPrivate::SaveSample()
 {
   // Attempt to create the directories if they don't exist

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -27,16 +27,6 @@
 #include <ignition/transport/Node.hh>
 #include <ignition/transport/TopicUtils.hh>
 
-// \todo(iche033) Remove these includes when HasConnections() function
-// becomes virtual
-#include "ignition/sensors/AirPressureSensor.hh"
-#include "ignition/sensors/AltimeterSensor.hh"
-#include "ignition/sensors/ForceTorqueSensor.hh"
-#include "ignition/sensors/ImuSensor.hh"
-#include "ignition/sensors/LogicalCameraSensor.hh"
-#include "ignition/sensors/MagnetometerSensor.hh"
-#include "ignition/sensors/NavSatSensor.hh"
-
 using namespace ignition::sensors;
 
 class ignition::sensors::SensorPrivate
@@ -122,10 +112,6 @@ class ignition::sensors::SensorPrivate
 
   /// \brief If sensor is active or not.
   public: bool active = true;
-
-  /// \brief Sensor class extention
-  /// \todo(iche033) remove once HasConnections() becomes virtual
-  public: std::shared_ptr<SensorExt> sensorExt;
 };
 
 SensorId SensorPrivate::idCounter = 0;
@@ -188,8 +174,6 @@ Sensor::Sensor() :
   dataPtr(new SensorPrivate)
 {
   this->dataPtr->id = (++this->dataPtr->idCounter);
-  this->dataPtr->sensorExt = std::make_shared<SensorExt>(this);
-  this->SetExtension(this->dataPtr->sensorExt);
 }
 
 //////////////////////////////////////////////////
@@ -469,10 +453,6 @@ bool Sensor::Update(const std::chrono::steady_clock::duration &_now,
   if (!this->dataPtr->active && !_force)
     return result;
 
-  // prevent update if no subscribers, unless forced
-  if (!this->HasConnections() && !_force)
-    return result;
-
   // Make the update happen
   result = this->Update(_now);
 
@@ -540,65 +520,4 @@ bool Sensor::IsActive() const
 void Sensor::SetActive(bool _active)
 {
   this->dataPtr->active = _active;
-}
-
-/////////////////////////////////////////////////
-bool Sensor::HasConnections() const
-{
-  return this->dataPtr->sensorExt->HasConnections();
-}
-
-/////////////////////////////////////////////////
-void Sensor::SetExtension(const std::shared_ptr<SensorExt> &_sensor)
-{
-  this->dataPtr->sensorExt = _sensor;
-}
-
-//////////////////////////////////////////////////
-SensorExt::SensorExt(Sensor *_sensor)
-{
-  this->sensor = _sensor;
-}
-
-/////////////////////////////////////////////////
-bool SensorExt::HasConnections() const
-{
-  // \todo(iche033) Make this function virtual and let derived classes
-  // override this function
-  {
-    auto s = dynamic_cast<const AirPressureSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const AltimeterSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const ForceTorqueSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const ImuSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const LogicalCameraSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const MagnetometerSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<const NavSatSensor *>(this->sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  return true;
 }

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -453,6 +453,10 @@ bool Sensor::Update(const std::chrono::steady_clock::duration &_now,
   if (!this->dataPtr->active && !_force)
     return result;
 
+  // prevent update if no subscribers, unless forced
+  if (!this->HasConnections() && !_force)
+    return result;
+
   // Make the update happen
   result = this->Update(_now);
 
@@ -520,4 +524,12 @@ bool Sensor::IsActive() const
 void Sensor::SetActive(bool _active)
 {
   this->dataPtr->active = _active;
+}
+
+/////////////////////////////////////////////////
+bool Sensor::HasConnections() const
+{
+  // by default assume there is also someone who needs data
+  // override the return value in base class
+  return true;
 }

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -651,3 +651,11 @@ bool ThermalCameraSensorPrivate::SaveImage(const uint16_t *_data,
   return true;
 }
 
+//////////////////////////////////////////////////
+bool ThermalCameraSensor::HasConnections() const
+{
+  return (this->dataPtr->thermalPub &&
+      this->dataPtr->thermalPub.HasConnections()) ||
+      this->dataPtr->imageEvent.ConnectionCount() > 0u;
+}
+

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -658,4 +658,3 @@ bool ThermalCameraSensor::HasConnections() const
       this->dataPtr->thermalPub.HasConnections()) ||
       this->dataPtr->imageEvent.ConnectionCount() > 0u;
 }
-

--- a/test/integration/air_pressure.cc
+++ b/test/integration/air_pressure.cc
@@ -174,6 +174,7 @@ TEST_F(AirPressureSensorTest, SensorReadings)
   auto sensor = sf.CreateSensor<ignition::sensors::AirPressureSensor>(
       airPressureSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   auto sensorNoise = sf.CreateSensor<ignition::sensors::AirPressureSensor>(
       airPressureSdfNoise);
@@ -197,6 +198,7 @@ TEST_F(AirPressureSensorTest, SensorReadings)
 
   // verify msg received on the topic
   WaitForMessageTestHelper<ignition::msgs::FluidPressure> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
   sensor->Update(std::chrono::steady_clock::duration(std::chrono::seconds(1)));
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
   auto msg = msgHelper.Message();

--- a/test/integration/altimeter.cc
+++ b/test/integration/altimeter.cc
@@ -180,6 +180,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   auto sensor =
       sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   auto sensorNoise =
       sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdfNoise);
@@ -222,6 +223,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
 
   // verify msg received on the topic
   WaitForMessageTestHelper<ignition::msgs::Altimeter> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
   sensor->Update(std::chrono::steady_clock::duration(std::chrono::seconds(1)));
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
   auto msg = msgHelper.Message();

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -94,6 +94,7 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   ignition::sensors::CameraSensor *sensor =
       mgr.CreateSensor<ignition::sensors::CameraSensor>(sensorPtr);
   ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
   sensor->SetScene(scene);
 
   ASSERT_NE(sensor->RenderingCamera(), nullptr);
@@ -105,6 +106,8 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 
   std::string topic = "/test/integration/CameraPlugin_imagesWithBuiltinSDF";
   WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+
+  EXPECT_TRUE(sensor->HasConnections());
 
   // Update once to create image
   mgr.RunOnce(std::chrono::steady_clock::duration::zero());

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -230,6 +230,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::sensors::DepthCameraSensor *depthSensor =
       mgr.CreateSensor<ignition::sensors::DepthCameraSensor>(sensorPtr);
   ASSERT_NE(depthSensor, nullptr);
+  EXPECT_FALSE(depthSensor->HasConnections());
   depthSensor->SetScene(scene);
 
   EXPECT_EQ(depthSensor->ImageWidth(), static_cast<unsigned int>(imgWidth));
@@ -240,6 +241,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   std::string topic =
     "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image";
   WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+  EXPECT_TRUE(depthSensor->HasConnections());
 
   std::string pointsTopic =
     "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image/points";

--- a/test/integration/force_torque.cc
+++ b/test/integration/force_torque.cc
@@ -207,6 +207,7 @@ TEST_P(ForceTorqueSensorTest, SensorReadings)
       sf.CreateSensor<ignition::sensors::ForceTorqueSensor>(forcetorqueSdf);
 
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   // verify initial readings
   EXPECT_EQ(math::Vector3d::Zero, sensor->Force());
@@ -225,6 +226,7 @@ TEST_P(ForceTorqueSensorTest, SensorReadings)
 
   // verify msg received on the topic
   WaitForMessageTestHelper<ignition::msgs::Wrench> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
   auto dt = std::chrono::steady_clock::duration(std::chrono::seconds(1));
 
   // Set rotation of child

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -354,7 +354,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   node.Subscribe(topic, &::laserCb);
   node.Subscribe(topic + "/points", &::pointCb);
 
-  WaitForMessageTestHelper<ignition::msgs::LaserScan> helper(topic);
+  WaitForMessageTestHelper<ignition::msgs::LaserScan> helper(topic, true);
   // Update sensor
   mgr.RunOnce(std::chrono::steady_clock::duration::zero());
   EXPECT_TRUE(helper.WaitForMessage()) << helper;

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -220,6 +220,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
   // Make sure the above dynamic cast worked.
   ASSERT_NE(nullptr, sensor);
   sensor->SetScene(scene);
+  EXPECT_FALSE(sensor->HasConnections());
 
   // Set a callback on the lidar sensor to get a scan
   ignition::common::ConnectionPtr c =
@@ -229,6 +230,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
           std::placeholders::_4, std::placeholders::_5));
 
   EXPECT_TRUE(c != nullptr);
+  EXPECT_TRUE(sensor->HasConnections());
 
   double angleRes = (sensor->AngleMax() - sensor->AngleMin()).Radian() /
                     sensor->RayCount();
@@ -354,7 +356,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
 
   WaitForMessageTestHelper<ignition::msgs::LaserScan> helper(topic);
   // Update sensor
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
 
   int mid = horzSamples / 2;
@@ -527,7 +529,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   root->AddChild(visualBox3);
 
   // Update sensors
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
 
   int mid = horzSamples / 2;
   int last = (horzSamples - 1);
@@ -644,7 +646,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   sensor->SetScene(scene);
 
   // Update sensor
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
 
   unsigned int mid = horzSamples / 2;
   double unitBoxSize = 1.0;
@@ -790,7 +792,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   scene->PreRender();
 
   // Render and update
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
 
   // manually finish update scene
   scene->PostRender();

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -527,7 +527,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   root->AddChild(visualBox3);
 
   // Update sensors
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
 
   int mid = horzSamples / 2;
   int last = (horzSamples - 1);
@@ -644,7 +644,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   sensor->SetScene(scene);
 
   // Update sensor
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
 
   unsigned int mid = horzSamples / 2;
   double unitBoxSize = 1.0;
@@ -790,7 +790,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   scene->PreRender();
 
   // Render and update
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
 
   // manually finish update scene
   scene->PostRender();

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -354,9 +354,9 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   node.Subscribe(topic, &::laserCb);
   node.Subscribe(topic + "/points", &::pointCb);
 
-  WaitForMessageTestHelper<ignition::msgs::LaserScan> helper(topic, true);
+  WaitForMessageTestHelper<ignition::msgs::LaserScan> helper(topic);
   // Update sensor
-  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
 
   int mid = horzSamples / 2;

--- a/test/integration/imu.cc
+++ b/test/integration/imu.cc
@@ -114,9 +114,11 @@ TEST_F(ImuSensorTest, SensorReadings)
   ignition::sensors::SensorFactory sf;
   auto sensor = sf.CreateSensor<ignition::sensors::ImuSensor>(imuSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   // subscribe to the topic
   WaitForMessageTestHelper<ignition::msgs::IMU> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
 
   // verify initial readings
   EXPECT_EQ(ignition::math::Pose3d::Zero, sensor->WorldPose());

--- a/test/integration/logical_camera.cc
+++ b/test/integration/logical_camera.cc
@@ -38,6 +38,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
+#include "TransportTestTools.hh"
 
 // undefine near and far macros from windows.h
 #ifdef _WIN32
@@ -158,6 +159,17 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   auto sensor = sf.CreateSensor<ignition::sensors::LogicalCameraSensor>(
       logicalCameraSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
+
+//  std::cerr << "1 "<< std::endl;
+//  WaitForMessageTestHelper<ignition::msgs::LogicalCameraImage> helper(topic);
+//  std::cerr << "12"<< std::endl;
+//  EXPECT_TRUE(sensor->HasConnections());
+//  std::cerr << "3"<< std::endl;
+//  sensor->Update(std::chrono::steady_clock::duration::zero());
+//  std::cerr << "4"<< std::endl;
+//  EXPECT_TRUE(helper.WaitForMessage()) << helper;
+//  std::cerr << "54"<< std::endl;
 
   // verify initial image
   auto img = sensor->Image();
@@ -234,6 +246,12 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   img = sensor->Image();
   EXPECT_EQ(sensorPose4, ignition::msgs::Convert(img.pose()));
   EXPECT_EQ(0, img.model().size());
+
+  // verify connection count and msg published to topic
+  WaitForMessageTestHelper<ignition::msgs::LogicalCameraImage> helper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
+  sensor->Update(std::chrono::steady_clock::duration::zero());
+  EXPECT_TRUE(helper.WaitForMessage()) << helper;
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/logical_camera.cc
+++ b/test/integration/logical_camera.cc
@@ -161,16 +161,6 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   ASSERT_NE(nullptr, sensor);
   EXPECT_FALSE(sensor->HasConnections());
 
-//  std::cerr << "1 "<< std::endl;
-//  WaitForMessageTestHelper<ignition::msgs::LogicalCameraImage> helper(topic);
-//  std::cerr << "12"<< std::endl;
-//  EXPECT_TRUE(sensor->HasConnections());
-//  std::cerr << "3"<< std::endl;
-//  sensor->Update(std::chrono::steady_clock::duration::zero());
-//  std::cerr << "4"<< std::endl;
-//  EXPECT_TRUE(helper.WaitForMessage()) << helper;
-//  std::cerr << "54"<< std::endl;
-
   // verify initial image
   auto img = sensor->Image();
   EXPECT_EQ(0, img.model().size());

--- a/test/integration/magnetometer.cc
+++ b/test/integration/magnetometer.cc
@@ -185,6 +185,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   auto sensor = sf.CreateSensor<ignition::sensors::MagnetometerSensor>(
       magnetometerSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   auto sensorNoise = sf.CreateSensor<ignition::sensors::MagnetometerSensor>(
       magnetometerSdfNoise);
@@ -192,6 +193,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
 
   // subscribe to the topic
   WaitForMessageTestHelper<ignition::msgs::Magnetometer> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
 
   // subscribe to the topic
   WaitForMessageTestHelper<ignition::msgs::Magnetometer> msgHelperNoise(

--- a/test/integration/navsat.cc
+++ b/test/integration/navsat.cc
@@ -199,6 +199,7 @@ TEST_F(NavSatSensorTest, SensorReadings)
   SensorFactory sf;
   auto sensor = sf.CreateSensor<NavSatSensor>(navsatSdf);
   ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
 
   auto sensorNoise = sf.CreateSensor<NavSatSensor>(navsatSdfNoise);
   ASSERT_NE(nullptr, sensorNoise);
@@ -257,6 +258,7 @@ TEST_F(NavSatSensorTest, SensorReadings)
 
   // verify msg received on the topic
   WaitForMessageTestHelper<msgs::NavSat> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
   sensor->Update(std::chrono::steady_clock::duration(1s));
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
   auto msg = msgHelper.Message();

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -250,6 +250,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::sensors::RgbdCameraSensor *rgbdSensor =
       mgr.CreateSensor<ignition::sensors::RgbdCameraSensor>(sensorPtr);
   ASSERT_NE(rgbdSensor, nullptr);
+  EXPECT_FALSE(rgbdSensor->HasConnections());
   rgbdSensor->SetScene(scene);
 
   EXPECT_EQ(rgbdSensor->ImageWidth(), static_cast<unsigned int>(imgWidth));
@@ -258,6 +259,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
   std::string depthTopic =
     "/test/integration/RgbdCameraPlugin_imagesWithBuiltinSDF/depth_image";
   WaitForMessageTestHelper<ignition::msgs::Image> depthHelper(depthTopic);
+  EXPECT_TRUE(rgbdSensor->HasConnections());
 
   std::string imageTopic =
     "/test/integration/RgbdCameraPlugin_imagesWithBuiltinSDF/image";

--- a/test/integration/segmentation_camera.cc
+++ b/test/integration/segmentation_camera.cc
@@ -227,6 +227,7 @@ void SegmentationCameraSensorTest::ImagesWithBuiltinSDF(
     mgr.CreateSensor<ignition::sensors::SegmentationCameraSensor>(sdfSensor);
 
   ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
   sensor->SetScene(scene);
 
   EXPECT_EQ(width, static_cast<int>(sensor->ImageWidth()));
@@ -253,6 +254,7 @@ void SegmentationCameraSensorTest::ImagesWithBuiltinSDF(
   topic += "/labels_map";
 
   WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
   WaitForMessageTestHelper<ignition::msgs::CameraInfo> infoHelper(infoTopic);
 
   // Update once to create image

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -177,6 +177,7 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::sensors::ThermalCameraSensor *thermalSensor =
       mgr.CreateSensor<ignition::sensors::ThermalCameraSensor>(sensorPtr);
   ASSERT_NE(thermalSensor, nullptr);
+  EXPECT_FALSE(thermalSensor->HasConnections());
 
   float ambientTemp = 296.0f;
   float ambientTempRange = 4.0f;
@@ -192,6 +193,7 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
   std::string topic =
     "/test/integration/ThermalCameraPlugin_imagesWithBuiltinSDF/image";
   WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+  EXPECT_TRUE(thermalSensor->HasConnections());
 
   std::string infoTopic =
     "/test/integration/ThermalCameraPlugin_imagesWithBuiltinSDF/camera_info";

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -102,6 +102,7 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   ignition::sensors::CameraSensor *sensor =
       mgr.CreateSensor<ignition::sensors::CameraSensor>(sensorPtr);
   ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
   sensor->SetScene(scene);
 
   sdf::Sensor sdfSensor;
@@ -118,6 +119,7 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
     std::string imageTopic =
         "/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF";
     WaitForMessageTestHelper<ignition::msgs::Image> helper(imageTopic);
+    EXPECT_TRUE(sensor->HasConnections());
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
     EXPECT_FALSE(helper.WaitForMessage(3s)) << helper;
   }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>
# 🎉 New feature

## Summary

Add `HasConnection` function to all sensors. The main motivation is to so that users of sensors can check to see if there are any subscribers / connections to the sensor data. If none, they can avoid doing any unnecessary computation, see https://github.com/gazebosim/gz-sim/pull/1480

Each sensor has its own publishers and events so each needs different implementation. Note that I had to change the `GpuLidarSensor` class' event callback implementation slightly so that I can keep track of the event connection count. The changes also make it more consistent with other rendering sensors event callbacks.

## Test it

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

