### PR TITLE
Sets lidar visibility mask

### DIFF
--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -235,6 +235,9 @@ namespace ignition
 
       // Documentation inherited
       public: virtual bool IsActive() const;
+      /// \brief Get the visibility mask
+      /// \return Visibility mask
+      public: uint32_t VisibilityMask() const;
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Just a mutex for thread safety

--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -235,6 +235,7 @@ namespace ignition
 
       // Documentation inherited
       public: virtual bool IsActive() const;
+
       /// \brief Get the visibility mask
       /// \return Visibility mask
       public: uint32_t VisibilityMask() const;

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -211,6 +211,7 @@ bool GpuLidarSensor::CreateLidar()
   this->dataPtr->pointMsg.set_row_step(
       this->dataPtr->pointMsg.point_step() *
       this->dataPtr->pointMsg.width());
+  this->dataPtr->gpuRays->SetVisibilityMask(this->VisibilityMask());
 
   this->AddSensor(this->dataPtr->gpuRays);
 

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -446,6 +446,11 @@ int Lidar::Fiducial(const unsigned int /*_index*/) const
   return -1;
 }
 
+//////////////////////////////////////////////////
+uint32_t Lidar::VisibilityMask() const
+{
+  return this->dataPtr->sdfLidar.VisibilityMask();
+}
 
 //////////////////////////////////////////////////
 bool Lidar::IsActive() const

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -136,7 +136,8 @@ TEST(Lidar_TEST, CreateLaser)
   sdf::ElementPtr lidarSDF = LidarToSDF(name, update_rate, topic,
     horz_samples, horz_resolution, horz_min_angle, horz_max_angle,
     vert_samples, vert_resolution, vert_min_angle, vert_max_angle,
-    range_resolution, range_min, range_max, visibility_mask, always_on, visualize);
+    range_resolution, range_min, range_max, visibility_mask, always_on,
+    visualize);
 
   // Create a CameraSensor
   ignition::sensors::Lidar *sensor = mgr.CreateSensor<ignition::sensors::Lidar>(

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -38,7 +38,7 @@ sdf::ElementPtr LidarToSDF(const std::string &name, double update_rate,
     double horz_min_angle, double horz_max_angle, double vert_samples,
     double vert_resolution, double vert_min_angle, double vert_max_angle,
     double range_resolution, double range_min, double range_max,
-    bool always_on, bool visualize)
+    uint32_t visibility_mask, bool always_on, bool visualize)
 {
   std::ostringstream stream;
   stream
@@ -69,6 +69,7 @@ sdf::ElementPtr LidarToSDF(const std::string &name, double update_rate,
     << "          <max>" << range_max << "</max>"
     << "          <resolution>" << range_resolution << "</resolution>"
     << "        </range>"
+    << "        <visibility_mask>" << visibility_mask << "</visibility_mask>"
     << "      </ray>"
     << "      <always_on>"<< always_on <<"</always_on>"
     << "      <visualize>" << visualize << "</visualize>"
@@ -128,13 +129,14 @@ TEST(Lidar_TEST, CreateLaser)
   const double range_resolution = 0.01;
   const double range_min = 0.08;
   const double range_max = 10.0;
+  const uint32_t visibility_mask = 1234u;
   const bool always_on = 1;
   const bool visualize = 1;
 
   sdf::ElementPtr lidarSDF = LidarToSDF(name, update_rate, topic,
     horz_samples, horz_resolution, horz_min_angle, horz_max_angle,
     vert_samples, vert_resolution, vert_min_angle, vert_max_angle,
-    range_resolution, range_min, range_max, always_on, visualize);
+    range_resolution, range_min, range_max, visibility_mask, always_on, visualize);
 
   // Create a CameraSensor
   ignition::sensors::Lidar *sensor = mgr.CreateSensor<ignition::sensors::Lidar>(
@@ -158,6 +160,7 @@ TEST(Lidar_TEST, CreateLaser)
   EXPECT_EQ(sensor->VerticalRangeCount(), 1u);
   EXPECT_DOUBLE_EQ(sensor->VerticalAngleMin().Radian(), 0.0);
   EXPECT_DOUBLE_EQ(sensor->VerticalAngleMax().Radian(), 0.0);
+  EXPECT_EQ(1234u, sensor->VisibilityMask());
 
   EXPECT_TRUE(sensor->IsActive());
 }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

Depends on:
* https://github.com/gazebosim/sdformat/pull/1015
* https://github.com/gazebosim/gz-rendering/pull/625

## Summary
Extends GpuLidarSensor to read the new `<visibility_mask>` SDF element introduced in https://github.com/gazebosim/sdformat/pull/1015 and sets it to the ign-rendernig GpuRays object.

## Test it

Here is an example ign-gazebo world thats show a lidar with visibility mask set. The lidar sees only 2 boxes out of 3. The one that is invisible to the lidar has visibility flags set to value that evaluates to non-zero when bitwise AND'd with the lidar's visbility mask. The smoke is there to test and verify that particle system still affects the lidar readings


![lidar_visibility_mask](https://user-images.githubusercontent.com/4000684/167953570-c3c765b6-063e-462e-b689-17936a5e8e02.png)

<details><summary>lidar_visibility_mask.sdf</summary>

```xml
<?xml version="1.0" ?>

<sdf version="1.9">
  <world name="lidar_visibility_mask">

    <physics name="1ms" type="ode">
      <max_step_size>0.001</max_step_size>
      <real_time_factor>1.0</real_time_factor>
    </physics>
    <plugin
      filename="ignition-gazebo-physics-system"
      name="ignition::gazebo::systems::Physics">
    </plugin>
    <plugin
      filename="ignition-gazebo-user-commands-system"
      name="ignition::gazebo::systems::UserCommands">
    </plugin>
    <plugin
      filename="ignition-gazebo-sensors-system"
      name="ignition::gazebo::systems::Sensors">
      <render_engine>ogre2</render_engine>
    </plugin>

    <plugin
      filename="ignition-gazebo-scene-broadcaster-system"
      name="ignition::gazebo::systems::SceneBroadcaster">
    </plugin>

    <scene>
      <ambient>1.0 1.0 1.0</ambient>
      <background>0.8 0.8 0.8</background>
      <sky></sky>
    </scene>

    <light type="directional" name="sun">
      <cast_shadows>true</cast_shadows>
      <pose>0 0 10 0 0 0</pose>
      <diffuse>1 1 1 1</diffuse>
      <specular>0.5 0.5 0.5 1</specular>
      <attenuation>
        <range>1000</range>
        <constant>0.9</constant>
        <linear>0.01</linear>
        <quadratic>0.001</quadratic>
      </attenuation>
      <direction>-0.5 0.1 -0.9</direction>
    </light>

    <model name="ground_plane">
      <static>true</static>
      <link name="link">
        <collision name="collision">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
            </plane>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
          <material>
            <ambient>0.8 0.8 0.8 1</ambient>
            <diffuse>0.8 0.8 0.8 1</diffuse>
            <specular>0.8 0.8 0.8 1</specular>
          </material>
        </visual>
      </link>
    </model>

    <include>
      <uri>https://fuel.ignitionrobotics.org/1.0/caguero/models/smoke_generator/2</uri>
    </include>

    <model name="lidar">
      <pose>4 0 0.5 0 0.0 3.14</pose>
      <static>true</static>
      <link name="link">
        <pose>0.05 0.05 0.05 0 0 0</pose>
        <collision name="collision">
          <geometry>
            <box>
              <size>0.1 0.1 0.1</size>
            </box>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <box>
              <size>0.1 0.1 0.1</size>
            </box>
          </geometry>
        </visual>

        <sensor name='gpu_lidar' type='gpu_lidar'>"
          <topic>lidar</topic>
          <update_rate>10</update_rate>
          <ray>
            <scan>
              <horizontal>
                <samples>640</samples>
                <resolution>1</resolution>
                <min_angle>-1.396263</min_angle>
                <max_angle>1.396263</max_angle>
              </horizontal>
              <vertical>
                <samples>1</samples>
                <resolution>0.01</resolution>
                <min_angle>0</min_angle>
                <max_angle>0</max_angle>
              </vertical>
            </scan>
            <range>
              <min>0.08</min>
              <max>10.0</max>
              <resolution>0.01</resolution>
            </range>
            <visibility_mask>55</visibility_mask>
          </ray>
          <alwaysOn>1</alwaysOn>
          <visualize>true</visualize>
        </sensor>
      </link>
    </model>

    <model name="box_no_visbility_flags">
      <static>true</static>
      <pose>1 0 0.5 0 0.0 3.14</pose>
      <link name="link">
        <collision name="collision">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
        </visual>
      </link>
    </model>

    <model name="box_invisible">
      <static>true</static>
      <pose>1 1 0.5 0 0.0 3.14</pose>
      <link name="link">
        <collision name="collision">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
          <visibility_flags>8</visibility_flags>
        </visual>
      </link>
    </model>

    <model name="box_visible">
      <static>true</static>
      <pose>1 -1 0.5 0 0.0 3.14</pose>
      <link name="link">
        <collision name="collision">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <box>
              <size>0.5 0.5 0.5</size>
            </box>
          </geometry>
          <visibility_flags>16</visibility_flags>
        </visual>
      </link>
    </model>

  </world>
</sdf>
```

</details>

1. launch `lidar_visibility_mask.sdf` world
    ```
    ign gazebo -v 4 -r lidar_visibility_mask.sdf`
    ```
1. Go to the top right 3 dot menu and open `Visualize lidar` gui plugin
1. Click on the refresh icon to see the lidar readings

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

