### PR TITLE
Add support for single channel 16 bit grayscale image format

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -217,6 +217,8 @@ bool CameraSensor::CreateCamera()
     case sdf::PixelFormatType::L_INT8:
       this->dataPtr->camera->SetImageFormat(ignition::rendering::PF_L8);
       break;
+    case sdf::PixelFormatType::L_INT16:
+      this->dataPtr->camera->SetImageFormat(ignition::rendering::PF_L16);
     default:
       ignerr << "Unsupported pixel format ["
         << static_cast<int>(pixelFormat) << "]\n";
@@ -443,6 +445,10 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
     case ignition::rendering::PF_L8:
       format = ignition::common::Image::L_INT8;
       msgsPixelFormat = msgs::PixelFormatType::L_INT8;
+      break;
+    case ignition::rendering::PF_L16:
+      format = ignition::common::Image::L_INT16;
+      msgsPixelFormat = msgs::PixelFormatType::L_INT16;
       break;
     default:
       ignerr << "Unsupported pixel format ["


### PR DESCRIPTION
## Summary
This PR adds support for 16 bit grayscale image format full description here #73 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request

