### PR TITLE
Remove deprecated common/PluginMacros.hh include

### DIFF
--- a/include/gz/sensors/SegmentationCameraSensor.hh
+++ b/include/gz/sensors/SegmentationCameraSensor.hh
@@ -22,7 +22,6 @@
 #include <string>
 
 #include <gz/common/Event.hh>
-#include <gz/common/PluginMacros.hh>
 #include <gz/utils/SuppressWarning.hh>
 #include <gz/msgs.hh>
 #include <gz/transport/Node.hh>


### PR DESCRIPTION
This was removed in https://github.com/gazebosim/gz-common/pull/350 , and is deprecated/dangling/no longer needed (: