### PR TITLE
Use pose multiplication instead of subtraction

### DIFF
--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -155,7 +155,7 @@ bool LogicalCameraSensor::Update(
       msgs::LogicalCameraImage::Model *modelMsg =
           this->dataPtr->msg.add_model();
       modelMsg->set_name(it.first);
-      msgs::Set(modelMsg->mutable_pose(), it.second - this->Pose());
+      msgs::Set(modelMsg->mutable_pose(), this->Pose().Inverse() * it.second);
     }
   }
   *this->dataPtr->msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);

--- a/test/integration/logical_camera.cc
+++ b/test/integration/logical_camera.cc
@@ -183,7 +183,7 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   EXPECT_EQ(sensorPose, gz::msgs::Convert(img.pose()));
   EXPECT_EQ(1, img.model().size());
   EXPECT_EQ(boxName, img.model(0).name());
-  gz::math::Pose3d boxPoseCameraFrame = boxPose - sensorPose;
+  gz::math::Pose3d boxPoseCameraFrame = sensorPose.Inverse() * boxPose;
   EXPECT_EQ(boxPoseCameraFrame, gz::msgs::Convert(img.model(0).pose()));
 
   // 2. test box outside of frustum
@@ -221,7 +221,7 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   EXPECT_EQ(sensorPose3, gz::msgs::Convert(img.pose()));
   EXPECT_EQ(1, img.model().size());
   EXPECT_EQ(boxName, img.model(0).name());
-  gz::math::Pose3d boxPose3CameraFrame = boxPose3 - sensorPose3;
+  gz::math::Pose3d boxPose3CameraFrame = sensorPose3.Inverse() * boxPose3;
   EXPECT_EQ(boxPose3CameraFrame, gz::msgs::Convert(img.model(0).pose()));
 
   // 4. rotate camera away and image should be empty


### PR DESCRIPTION
# 🎉 New feature

Part of [gz-math#60](https://github.com/gazebosim/gz-math/issues/60).

## Summary

As noted in [gz-math#60](https://github.com/gazebosim/gz-math/issues/60), there are concerns about the pose subtraction operator. Given that it is equivalent to multiplying by an inverse (albeit with reversed order), the subtraction operator will be deprecated. This PR replaces usage of the soon-to-be-deprecated operator with the equivalent multiplication by inverse.

## Test it

Build against https://github.com/gazebosim/gz-math/pull/438 and confirm that tests still pass and that there are no deprecation warnings.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
