### PR TITLE
Disable thermal camera test on MacOS

### DIFF
--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2019 Open Source Robotics Foundation
  *
@@ -32,6 +33,7 @@
 #include <ignition/common/Event.hh>
 #include <ignition/sensors/Manager.hh>
 #include <ignition/sensors/ThermalCameraSensor.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 // TODO(louise) Remove these pragmas once ign-rendering is disabling the
 // warnings
@@ -357,7 +359,9 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(ThermalCameraSensorTest, ImagesWithBuiltinSDF)
+// See: https://github.com/gazebosim/gz-rendering/issues/654
+TEST_P(ThermalCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_MAC(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

## Summary
Disabling a faling test on MacOS, I think it's closely related to same error described here: https://github.com/gazebosim/gz-rendering/issues/654. I think it's better to track both issues together, I can open a new issue if it's preferred for this test.

Should fix remaining test regression on MacOS + Fortress buildfarm jobs.
Reference, see: https://build.osrfoundation.org/job/ignition_sensors-ci-ign-sensors6-homebrew-amd64/25/
FYI: @Crola1702

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.