### PR TITLE
Add optional optical frame id to camera sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ set(IGN_MSGS_VER ${ignition-msgs8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find SDFormat
-ign_find_package(sdformat12 REQUIRED VERSION 12.5.0)
+ign_find_package(sdformat12 REQUIRED VERSION 12.6.0)
 set(SDF_VER ${sdformat12_VERSION_MAJOR})
 
 set(IGN_SENSORS_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -129,6 +129,9 @@ class ignition::sensors::CameraSensorPrivate
   /// \brief Camera information message.
   public: msgs::CameraInfo infoMsg;
 
+  /// \brief The frame this camera uses in its camera_info topic.
+  public: std::string opticalFrameId{""};
+
   /// \brief Topic for info message.
   public: std::string infoTopic{""};
 
@@ -462,7 +465,7 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
     *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
     auto frame = msg.mutable_header()->add_data();
     frame->set_key("frame_id");
-    frame->add_value(this->FrameId());
+    frame->add_value(this->dataPtr->opticalFrameId);
     msg.set_data(data, this->dataPtr->camera->ImageMemorySize());
   }
 
@@ -676,11 +679,20 @@ void CameraSensor::PopulateInfo(const sdf::Camera *_cameraSdf)
 
   // Note: while Gazebo interprets the camera frame to be looking towards +X,
   // other tools, such as ROS, may interpret this frame as looking towards +Z.
-  // TODO(anyone) Expose the `frame_id` as an SDF parameter so downstream users
-  // can populate it with arbitrary frames.
+  // To make this configurable the user has the option to set an optical frame.
+  // If the user has set <optical_frame_id> in the cameraSdf use it,
+  // otherwise fall back to the sensor frame.
+  if (_cameraSdf->OpticalFrameId().empty())
+  {
+   this->dataPtr->opticalFrameId = this->FrameId();
+  }
+  else
+  {
+   this->dataPtr->opticalFrameId = _cameraSdf->OpticalFrameId();
+  }
   auto infoFrame = this->dataPtr->infoMsg.mutable_header()->add_data();
   infoFrame->set_key("frame_id");
-  infoFrame->add_value(this->FrameId());
+  infoFrame->add_value(this->dataPtr->opticalFrameId);
 
   this->dataPtr->infoMsg.set_width(width);
   this->dataPtr->infoMsg.set_height(height);


### PR DESCRIPTION
# 🎉 New feature

Closes #175 

## Summary
This adds the ability for a `CameraSensor` or `RgbdCameraSensor` to use the optional sdf specified `optical frame_id` that will be used when publishing the camera_info, rgb_image, and point_cloud topic's from a simulated sensor.  Note: this PR depends on an open [PR in sdformat](https://github.com/gazebosim/sdformat/pull/1109).
This feature request was noted in [CameraSensors.cc](https://github.com/gazebosim/gz-sensors/blob/ign-sensors6/src/CameraSensor.cc#L677-L680) and will help close https://github.com/ignitionrobotics/ign-sensors/issues/175 in ign-sensors.

## Test it
Here are the instructions on how I setup my test environment:
- I started with the following Docker image from Open Robotics. `osrf/ros:humble-desktop`
- Clone an [example repo](https://github.com/MarqRazz/rgbd_camera_ignition) that I created. You can see that I set `optical_frame_id` [here](https://github.com/MarqRazz/rgbd_camera_ignition/blob/3cdb4e085212cb9e9213a1e3eead195d62456f9f/urdf/rgbd_macro.gazebo.urdf.xacro#L193). You will also need to clone some dependencies with `vcs import src --skip-existing --input src/rgbd_camera_ignition/rgbd_camera_ignition.repos`
- Build Ignition Gazebo from [source](https://gazebosim.org/docs/fortress/install_ubuntu_src) including [sdformat#1109](https://github.com/gazebosim/sdformat/pull/1109) and this PR.
- Run Gazebo and Rviz with `ros2 launch rgbd_camera_ignition rgbd_ignition.launch.py`

Rviz should appear with the point cloud being rendered in the 6-DOF scene and the `Camera` widget properly overlaying it over the RGB image.
![image](https://user-images.githubusercontent.com/25058794/184409207-b63db3c6-9447-4642-99fb-1cfe6feb20a4.png)

I even made a custom frustum mesh (not included in my repo) to ensure the camera was rendering in the correct location in Gazebo and Rviz.
![gazebo_depth_camera](https://user-images.githubusercontent.com/25058794/184409449-37d0e6f3-3091-4b98-9bc9-bb75aa62dd6c.gif)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.