### PR TITLE
Add missing DEPENDS_ON_COMPONENTS parameters

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,11 @@ target_link_libraries(${rendering_target}
 )
 
 set(camera_sources CameraSensor.cc)
-ign_add_component(camera SOURCES ${camera_sources} GET_TARGET_NAME camera_target)
+ign_add_component(camera
+  SOURCES ${camera_sources}
+  DEPENDS_ON_COMPONENTS rendering
+  GET_TARGET_NAME camera_target
+)
 # custom compile definitions since the one provided automatically is versioned and will
 # make the code need to change with every major version
 target_compile_definitions(${camera_target} PUBLIC CameraSensor_EXPORTS)
@@ -66,7 +70,11 @@ target_link_libraries(${camera_target}
 )
 
 set(depth_camera_sources DepthCameraSensor.cc)
-ign_add_component(depth_camera SOURCES ${depth_camera_sources} GET_TARGET_NAME depth_camera_target)
+ign_add_component(depth_camera
+  SOURCES ${depth_camera_sources}
+  DEPENDS_ON_COMPONENTS camera
+  GET_TARGET_NAME depth_camera_target
+)
 target_compile_definitions(${depth_camera_target} PUBLIC DepthCameraSensor_EXPORTS)
 target_link_libraries(${depth_camera_target}
   PRIVATE
@@ -76,7 +84,11 @@ target_link_libraries(${depth_camera_target}
 )
 
 set(lidar_sources Lidar.cc)
-ign_add_component(lidar SOURCES ${lidar_sources} GET_TARGET_NAME lidar_target)
+ign_add_component(lidar
+  SOURCES ${lidar_sources}
+  DEPENDS_ON_COMPONENTS rendering
+  GET_TARGET_NAME lidar_target
+)
 target_compile_definitions(${lidar_target} PUBLIC Lidar_EXPORTS)
 target_link_libraries(${lidar_target}
   PUBLIC
@@ -90,7 +102,8 @@ set(gpu_lidar_sources GpuLidarSensor.cc)
 ign_add_component(gpu_lidar
   DEPENDS_ON_COMPONENTS lidar
   SOURCES ${gpu_lidar_sources}
-  GET_TARGET_NAME gpu_lidar_target)
+  GET_TARGET_NAME gpu_lidar_target
+)
 target_compile_definitions(${gpu_lidar_target} PUBLIC GpuLidarSensor_EXPORTS)
 target_link_libraries(${gpu_lidar_target}
   PRIVATE
@@ -121,7 +134,11 @@ set(air_pressure_sources AirPressureSensor.cc)
 ign_add_component(air_pressure SOURCES ${air_pressure_sources} GET_TARGET_NAME air_pressure_target)
 
 set(rgbd_camera_sources RgbdCameraSensor.cc)
-ign_add_component(rgbd_camera SOURCES ${rgbd_camera_sources} GET_TARGET_NAME rgbd_camera_target)
+ign_add_component(rgbd_camera
+  SOURCES ${rgbd_camera_sources}
+  DEPENDS_ON_COMPONENTS camera
+  GET_TARGET_NAME rgbd_camera_target
+)
 target_compile_definitions(${rgbd_camera_target} PUBLIC RgbdCameraSensor_EXPORTS)
 target_link_libraries(${rgbd_camera_target}
   PRIVATE
@@ -131,7 +148,11 @@ target_link_libraries(${rgbd_camera_target}
 )
 
 set(thermal_camera_sources ThermalCameraSensor.cc)
-ign_add_component(thermal_camera SOURCES ${thermal_camera_sources} GET_TARGET_NAME thermal_camera_target)
+ign_add_component(thermal_camera
+  SOURCES ${thermal_camera_sources}
+  DEPENDS_ON_COMPONENTS camera
+  GET_TARGET_NAME thermal_camera_target
+)
 target_link_libraries(${thermal_camera_target}
   PRIVATE
     ${camera_target}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,10 @@ target_link_libraries(${lidar_target}
 )
 
 set(gpu_lidar_sources GpuLidarSensor.cc)
-ign_add_component(gpu_lidar SOURCES ${gpu_lidar_sources} GET_TARGET_NAME gpu_lidar_target)
+ign_add_component(gpu_lidar
+  DEPENDS_ON_COMPONENTS lidar
+  SOURCES ${gpu_lidar_sources}
+  GET_TARGET_NAME gpu_lidar_target)
 target_compile_definitions(${gpu_lidar_target} PUBLIC GpuLidarSensor_EXPORTS)
 target_link_libraries(${gpu_lidar_target}
   PRIVATE


### PR DESCRIPTION
# 🦟 Bug fix

Fixes homebrew build of ign-gazebo3 https://github.com/osrf/homebrew-simulation/pull/2008, alternative to https://github.com/gazebosim/gz-sim/pull/1663

## Summary

The ign-gazebo3 builds have been failing since ign-sensors 3.4.0 was released (see https://github.com/osrf/homebrew-simulation/pull/2008#issuecomment-1228761373).

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo3-homebrew-amd64&build=246)](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/246/) https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/246/

From the cmake output:

~~~
-- Searching for dependencies of ignition-sensors3-gpu_lidar
...
  Found package configuration file:

    /usr/local/lib/cmake/ignition-sensors3-gpu_lidar/ignition-sensors3-gpu_lidar-config.cmake

  but it set ignition-sensors3-gpu_lidar_FOUND to FALSE so package
  "ignition-sensors3-gpu_lidar" is considered to be NOT FOUND.  Reason given
  by package:

  The following imported targets are referenced, but are missing:
  ignition-sensors3::ignition-sensors3-lidar
...
-- Looking for ignition-sensors3 - not found
~~~

There are some component libraries that link to other component libraries but they also need to declare those dependencies with the `DEPENDS_ON_COMPONENTS` parameter to `ign_add_component` (see [gz-physics/dartsim](https://github.com/gazebosim/gz-physics/blob/4ef1d65648276f79c470552cb08f98e4a4e17514/dartsim/CMakeLists.txt#L4) for example). This adds all the missing `DEPENDS_ON_COMPONENTS` calls that I could see, and fixes the `ign-gazebo3` build in my local testing.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
