### PR TITLE
Clear scene before exiting wide_angle_camera_test

### DIFF
--- a/include/gz/sensors/WideAngleCameraSensor.hh
+++ b/include/gz/sensors/WideAngleCameraSensor.hh
@@ -141,8 +141,8 @@ namespace gz
       /// \brief Callback that is triggered when the scene changes on
       /// the Manager.
       /// \param[in] _scene Pointer to the new scene.
-      private: void OnSceneChange(gz::rendering::ScenePtr /*_scene*/)
-              { }
+      // private: void OnSceneChange(gz::rendering::ScenePtr /*_scene*/)
+              // { }
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/gz/sensors/WideAngleCameraSensor.hh
+++ b/include/gz/sensors/WideAngleCameraSensor.hh
@@ -138,12 +138,6 @@ namespace gz
       /// \return True on success.
       private: bool CreateCamera();
 
-      /// \brief Callback that is triggered when the scene changes on
-      /// the Manager.
-      /// \param[in] _scene Pointer to the new scene.
-      // private: void OnSceneChange(gz::rendering::ScenePtr /*_scene*/)
-              // { }
-
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -121,15 +121,12 @@ WideAngleCameraSensor::WideAngleCameraSensor()
 //////////////////////////////////////////////////
 WideAngleCameraSensor::~WideAngleCameraSensor()
 {
-  std::cerr << "wide angle sensor destructor 2" << std::endl;
   this->dataPtr->imageConnection.reset();
   if (this->dataPtr->imageBuffer)
   {
-    std::cerr << "wide angle sensor destructor 3" << std::endl;
     delete [] this->dataPtr->imageBuffer;
     this->dataPtr->imageBuffer = nullptr;
   }
-  std::cerr << "wide angle sensor destructor done " << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -121,12 +121,15 @@ WideAngleCameraSensor::WideAngleCameraSensor()
 //////////////////////////////////////////////////
 WideAngleCameraSensor::~WideAngleCameraSensor()
 {
+  std::cerr << "wide angle sensor destructor 2" << std::endl;
   this->dataPtr->imageConnection.reset();
   if (this->dataPtr->imageBuffer)
   {
+    std::cerr << "wide angle sensor destructor 3" << std::endl;
     delete [] this->dataPtr->imageBuffer;
     this->dataPtr->imageBuffer = nullptr;
   }
+  std::cerr << "wide angle sensor destructor done " << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -217,7 +217,13 @@ void WideAngleCameraSensorTest::ImagesWithBuiltinSDF(
   EXPECT_GT(b, g);
   EXPECT_GT(b, r);
 
+  auto sensorId = sensor->Id();
+  EXPECT_TRUE(mgr.Remove(sensorId));
+  EXPECT_EQ(nullptr, mgr.Sensor(sensorId));
+
   // Clean up
+  box.reset();
+  blue.reset();
   engine->DestroyScene(scene);
   gz::rendering::unloadEngine(engine->Name());
 }


### PR DESCRIPTION


# 🦟 Bug fix

This fixes the `INTEGRATION_wide_angle_camera` test for me locally on macOS. For some reason, we have to remove the sensor and scene visuals manually in this test otherwise it segfaults on macOS while cleaning up shared pointers. This does not happen on Ubuntu.

Related PR: https://github.com/gazebosim/gz-rendering/pull/718


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
