### PR TITLE
RgbdCameraSensor.cc: fix include

### DIFF
--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -19,8 +19,8 @@
   #pragma warning(push)
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
-#include <ignition/msgs/image.pb.h>
 #endif
+#include <ignition/msgs/image.pb.h>
 #include <ignition/msgs/pointcloud_packed.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #277

## Summary

Ensure that `image.pb.h` is included even when `_MSC_VER` is not defined.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
