### PR TITLE
Set custom projection matrix based on intrinsics params from SDF

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -65,6 +65,70 @@ class gz::sensors::CameraSensorPrivate
   public: bool SaveImage(const unsigned char *_data, unsigned int _width,
     unsigned int _height, gz::common::Image::PixelFormatType _format);
 
+
+  /// \brief Computes the OpenGL NDC matrix
+  /// \param[in] _left Left vertical clipping plane
+  /// \param[in] _right Right vertical clipping plane
+  /// \param[in] _bottom Bottom horizontal clipping plane
+  /// \param[in] _top Top horizontal clipping plane
+  /// \param[in] _near Distance to the nearer depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \param[in] _far Distance to the farther depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \return OpenGL NDC (Normalized Device Coordinates) matrix
+  public: static math::Matrix4d BuildNDCMatrix(
+          double _left, double _right,
+          double _bottom, double _top,
+          double _near, double _far);
+
+  /// \brief Computes the OpenGL perspective matrix
+  /// \param[in] _intrinsicsFx Horizontal focal length (in pixels)
+  /// \param[in] _intrinsicsFy Vertical focal length (in pixels)
+  /// \param[in] _intrinsicsCx X coordinate of principal point in pixels
+  /// \param[in] _intrinsicsCy Y coordinate of principal point in pixels
+  /// \param[in] _intrinsicsS Skew coefficient defining the angle between
+  ///            the x and y pixel axes
+  /// \param[in] _clipNear Distance to the nearer depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \param[in] _clipFar Distance to the farther depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \return OpenGL perspective matrix
+  public: static math::Matrix4d BuildPerspectiveMatrix(
+          double _intrinsicsFx, double _intrinsicsFy,
+          double _intrinsicsCx, double _intrinsicsCy,
+          double _intrinsicsS,
+          double _clipNear, double _clipFar);
+
+  /// \brief Computes the OpenGL projection matrix by multiplying
+  ///        the OpenGL Normalized Device Coordinates matrix (NDC) with
+  ///        the OpenGL perspective matrix
+  ///        openglProjectionMatrix = ndcMatrix * perspectiveMatrix
+  /// \param[in] _imageWidth Image width (in pixels)
+  /// \param[in] _imageHeight Image height (in pixels)
+  /// \param[in] _intrinsicsFx Horizontal focal length (in pixels)
+  /// \param[in] _intrinsicsFy Vertical focal length (in pixels)
+  /// \param[in] _intrinsicsCx X coordinate of principal point in pixels
+  /// \param[in] _intrinsicsCy Y coordinate of principal point in pixels
+  /// \param[in] _intrinsicsS Skew coefficient defining the angle between
+  ///             the x and y pixel axes
+  /// \param[in] _clipNear Distance to the nearer depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \param[in] _clipFar Distance to the farther depth clipping plane
+  ///            This value is negative if the plane is to be behind
+  ///            the camera
+  /// \return OpenGL projection matrix
+  public: static math::Matrix4d BuildProjectionMatrix(
+          double _imageWidth, double _imageHeight,
+          double _intrinsicsFx, double _intrinsicsFy,
+          double _intrinsicsCx, double _intrinsicsCy,
+          double _intrinsicsS,
+          double _clipNear, double _clipFar);
+
   /// \brief node to create publisher
   public: transport::Node node;
 
@@ -225,18 +289,6 @@ bool CameraSensor::CreateCamera()
       break;
   }
 
-  this->dataPtr->image = this->dataPtr->camera->CreateImage();
-
-  this->Scene()->RootVisual()->AddChild(this->dataPtr->camera);
-
-  // Create the directory to store frames
-  if (cameraSdf->SaveFrames())
-  {
-    this->dataPtr->saveImagePath = cameraSdf->SaveFramesPath();
-    this->dataPtr->saveImagePrefix = this->Name() + "_";
-    this->dataPtr->saveImage = true;
-  }
-
   // Update the DOM object intrinsics to have consistent
   // intrinsics between ogre camera and camera_info msg
   if(!cameraSdf->HasLensIntrinsics())
@@ -252,6 +304,34 @@ bool CameraSensor::CreateCamera()
     cameraSdf->SetLensIntrinsicsFy(intrinsicMatrix(1, 1));
     cameraSdf->SetLensIntrinsicsCx(intrinsicMatrix(0, 2));
     cameraSdf->SetLensIntrinsicsCy(intrinsicMatrix(1, 2));
+  }
+  // set custom projection matrix based on intrinsics param specified in sdf
+  else
+  {
+    double fx = cameraSdf->LensIntrinsicsFx();
+    double fy = cameraSdf->LensIntrinsicsFy();
+    double cx = cameraSdf->LensIntrinsicsCx();
+    double cy = cameraSdf->LensIntrinsicsCy();
+    double s = cameraSdf->LensIntrinsicsSkew();
+    auto projectionMatrix = CameraSensorPrivate::BuildProjectionMatrix(
+        this->dataPtr->camera->ImageWidth(),
+        this->dataPtr->camera->ImageHeight(),
+        fx, fy, cx, cy, s,
+        this->dataPtr->camera->NearClipPlane(),
+        this->dataPtr->camera->FarClipPlane());
+    this->dataPtr->camera->SetProjectionMatrix(projectionMatrix);
+  }
+
+  this->dataPtr->image = this->dataPtr->camera->CreateImage();
+
+  this->Scene()->RootVisual()->AddChild(this->dataPtr->camera);
+
+  // Create the directory to store frames
+  if (cameraSdf->SaveFrames())
+  {
+    this->dataPtr->saveImagePath = cameraSdf->SaveFramesPath();
+    this->dataPtr->saveImagePrefix = this->Name() + "_";
+    this->dataPtr->saveImage = true;
   }
 
   // Populate camera info topic
@@ -745,4 +825,75 @@ bool CameraSensor::HasConnections() const
 {
   return (this->dataPtr->pub && this->dataPtr->pub.HasConnections()) ||
       this->dataPtr->imageEvent.ConnectionCount() > 0u;
+}
+
+//////////////////////////////////////////////////
+math::Matrix4d CameraSensorPrivate::BuildProjectionMatrix(
+    double _imageWidth, double _imageHeight,
+    double _intrinsicsFx, double _intrinsicsFy,
+    double _intrinsicsCx, double _intrinsicsCy,
+    double _intrinsicsS,
+    double _clipNear, double _clipFar)
+{
+  return CameraSensorPrivate::BuildNDCMatrix(
+           0, _imageWidth, 0, _imageHeight, _clipNear, _clipFar) *
+           CameraSensorPrivate::BuildPerspectiveMatrix(
+             _intrinsicsFx, _intrinsicsFy,
+             _intrinsicsCx, _imageHeight - _intrinsicsCy,
+             _intrinsicsS, _clipNear, _clipFar);
+}
+
+//////////////////////////////////////////////////
+math::Matrix4d CameraSensorPrivate::BuildNDCMatrix(
+    double _left, double _right,
+    double _bottom, double _top,
+    double _near, double _far)
+{
+  double inverseWidth = 1.0 / (_right - _left);
+  double inverseHeight = 1.0 / (_top - _bottom);
+  double inverseDistance = 1.0 / (_far - _near);
+
+  return math::Matrix4d(
+           2.0 * inverseWidth,
+           0.0,
+           0.0,
+           -(_right + _left) * inverseWidth,
+           0.0,
+           2.0 * inverseHeight,
+           0.0,
+           -(_top + _bottom) * inverseHeight,
+           0.0,
+           0.0,
+           -2.0 * inverseDistance,
+           -(_far + _near) * inverseDistance,
+           0.0,
+           0.0,
+           0.0,
+           1.0);
+}
+
+//////////////////////////////////////////////////
+math::Matrix4d CameraSensorPrivate::BuildPerspectiveMatrix(
+    double _intrinsicsFx, double _intrinsicsFy,
+    double _intrinsicsCx, double _intrinsicsCy,
+    double _intrinsicsS,
+    double _clipNear, double _clipFar)
+{
+  return math::Matrix4d(
+           _intrinsicsFx,
+           _intrinsicsS,
+           -_intrinsicsCx,
+           0.0,
+           0.0,
+           _intrinsicsFy,
+           -_intrinsicsCy,
+           0.0,
+           0.0,
+           0.0,
+           _clipNear + _clipFar,
+           _clipNear * _clipFar,
+           0.0,
+           0.0,
+           -1.0,
+           0.0);
 }

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -65,7 +65,6 @@ class gz::sensors::CameraSensorPrivate
   public: bool SaveImage(const unsigned char *_data, unsigned int _width,
     unsigned int _height, gz::common::Image::PixelFormatType _format);
 
-
   /// \brief Computes the OpenGL NDC matrix
   /// \param[in] _left Left vertical clipping plane
   /// \param[in] _right Right vertical clipping plane

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -282,9 +282,9 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
 
   // Subscribe to the camera info topic
   gz::msgs::CameraInfo camera1Info, camera2Info, camera3Info;
-  unsigned int camera1Counter = 0;
-  unsigned int camera2Counter = 0;
-  unsigned int camera3Counter = 0;
+  unsigned int camera1Counter = 0u;
+  unsigned int camera2Counter = 0u;
+  unsigned int camera3Counter = 0u;
 
   std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
       [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
@@ -305,16 +305,16 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
     camera3Counter++;
   };
 
-  unsigned int height = 1000;
-  unsigned int width = 1000;
+  unsigned int height = 1000u;
+  unsigned int width = 1000u;
   unsigned int bpp = 3u;
   unsigned int imgBufferSize = width * height * bpp;
   unsigned char* img1 = new unsigned char[imgBufferSize];
   unsigned char* img2 = new unsigned char[imgBufferSize];
   unsigned char* img3 = new unsigned char[imgBufferSize];
-  unsigned int camera1DataCounter = 0;
-  unsigned int camera2DataCounter = 0;
-  unsigned int camera3DataCounter = 0;
+  unsigned int camera1DataCounter = 0u;
+  unsigned int camera2DataCounter = 0u;
+  unsigned int camera3DataCounter = 0u;
   std::function<void(const gz::msgs::Image &)> camera1Callback =
       [&img1, &camera1DataCounter, &imgBufferSize](const gz::msgs::Image & _msg)
   {
@@ -354,9 +354,9 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   while (!done && sleep++ < maxSleep)
   {
     std::lock_guard<std::mutex> lock(g_mutex);
-    done = (camera1Counter > 0 && camera2Counter > 0 && camera3Counter > 0 &&
-        camera1DataCounter > 0 && camera2DataCounter > 0 &&
-        camera3DataCounter > 0);
+    done = (camera1Counter > 0u && camera2Counter > 0u && camera3Counter > 0u &&
+        camera1DataCounter > 0u && camera2DataCounter > 0u &&
+        camera3DataCounter > 0u);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
@@ -399,9 +399,9 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
 
   // get sum of each color channel
   // all cameras should just see blue colors
-  for (unsigned int i = 0; i < height; ++i)
+  for (unsigned int i = 0u; i < height; ++i)
   {
-    for (unsigned int j = 0; j < step; j+=bpp)
+    for (unsigned int j = 0u; j < step; j+=bpp)
     {
       unsigned int idx = i * step + j;
       unsigned int r1 = img1[idx];
@@ -445,8 +445,6 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   EXPECT_EQ(r2Sum, r3Sum);
   EXPECT_EQ(g2Sum, g3Sum);
   EXPECT_NE(b2Sum, b3Sum);
-
-  std::cerr << r3Sum << " " << g3Sum << " " << b3Sum << std::endl;
 
   delete []  img1;
   delete []  img2;

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -195,6 +195,10 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   auto cameraWithIntrinsicsTag =
       linkPtr->GetElement("sensor")->GetNextElement();
 
+  // Camera sensor with different intrinsics tag
+  auto cameraWithDiffIntrinsicsTag =
+      cameraWithIntrinsicsTag->GetNextElement();
+
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
@@ -205,27 +209,66 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  scene->SetAmbientLight(1.0, 1.0, 1.0);
+
+  gz::rendering::VisualPtr root = scene->RootVisual();
+  ASSERT_NE(nullptr, root);
+
+  // create blue material
+  gz::rendering::MaterialPtr blue = scene->CreateMaterial();
+  blue->SetAmbient(0.0, 0.0, 0.3);
+  blue->SetDiffuse(0.0, 0.0, 0.8);
+  blue->SetSpecular(0.5, 0.5, 0.5);
+
+  // create box visual
+  gz::rendering::VisualPtr box = scene->CreateVisual("box");
+  ASSERT_NE(nullptr, box);
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(gz::math::Vector3d(4.0, 1, 0.5));
+  box->SetLocalRotation(0, 0, 0);
+  box->SetMaterial(blue);
+  root->AddChild(box);
 
   // Do the test
   gz::sensors::Manager mgr;
 
+  // there are 3 cameras:
+  //     - camera1: no intrinsics params
+  //     - camera2: has intrinsics params that are the same as default values
+  //     - camera3: has intrinsics params that are different from default values
+  // camera1 and camera2 should produce very similar images and camera3 should
+  // produce different images from 1 and 2.
   auto *sensor1 =
       mgr.CreateSensor<gz::sensors::CameraSensor>(cameraWithoutIntrinsicsTag);
   auto *sensor2 =
       mgr.CreateSensor<gz::sensors::CameraSensor>(cameraWithIntrinsicsTag);
+  auto *sensor3 =
+      mgr.CreateSensor<gz::sensors::CameraSensor>(cameraWithDiffIntrinsicsTag);
+
   ASSERT_NE(sensor1, nullptr);
   ASSERT_NE(sensor2, nullptr);
+  ASSERT_NE(sensor3, nullptr);
   sensor1->SetScene(scene);
   sensor2->SetScene(scene);
+  sensor3->SetScene(scene);
 
   std::string infoTopic1 = "/camera1/camera_info";
   std::string infoTopic2 = "/camera2/camera_info";
-  WaitForMessageTestHelper<gz::msgs::Image> helper1("/camera1/image");
+  std::string infoTopic3 = "/camera3/camera_info";
+  std::string imgTopic1 = "/camera1/image";
+  std::string imgTopic2 = "/camera2/image";
+  std::string imgTopic3 = "/camera3/image";
+  WaitForMessageTestHelper<gz::msgs::Image> helper1(imgTopic1);
   WaitForMessageTestHelper<gz::msgs::CameraInfo> helper2(infoTopic1);
-  WaitForMessageTestHelper<gz::msgs::Image> helper3("/camera2/image");
+  WaitForMessageTestHelper<gz::msgs::Image> helper3(imgTopic2);
   WaitForMessageTestHelper<gz::msgs::CameraInfo> helper4(infoTopic2);
+  WaitForMessageTestHelper<gz::msgs::Image> helper5(imgTopic3);
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper6(infoTopic3);
+
   EXPECT_TRUE(sensor1->HasConnections());
   EXPECT_TRUE(sensor2->HasConnections());
+  EXPECT_TRUE(sensor3->HasConnections());
 
   // Update once to create image
   mgr.RunOnce(std::chrono::steady_clock::duration::zero());
@@ -234,28 +277,72 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   EXPECT_TRUE(helper2.WaitForMessage()) << helper2;
   EXPECT_TRUE(helper3.WaitForMessage()) << helper3;
   EXPECT_TRUE(helper4.WaitForMessage()) << helper4;
+  EXPECT_TRUE(helper5.WaitForMessage()) << helper5;
+  EXPECT_TRUE(helper6.WaitForMessage()) << helper6;
 
   // Subscribe to the camera info topic
-  gz::msgs::CameraInfo camera1Info, camera2Info;
+  gz::msgs::CameraInfo camera1Info, camera2Info, camera3Info;
   unsigned int camera1Counter = 0;
   unsigned int camera2Counter = 0;
+  unsigned int camera3Counter = 0;
 
   std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
-      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg) {
-        camera1Info = _msg;
-        camera1Counter++;
+      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera1Info = _msg;
+    camera1Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
+      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera2Info = _msg;
+    camera2Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera3InfoCallback =
+      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera3Info = _msg;
+    camera3Counter++;
   };
 
-  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
-      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg) {
-        camera2Info = _msg;
-        camera2Counter++;
+  unsigned int height = 1000;
+  unsigned int width = 1000;
+  unsigned int bpp = 3u;
+  unsigned int imgBufferSize = width * height * bpp;
+  unsigned char* img1 = new unsigned char[imgBufferSize];
+  unsigned char* img2 = new unsigned char[imgBufferSize];
+  unsigned char* img3 = new unsigned char[imgBufferSize];
+  unsigned int camera1DataCounter = 0;
+  unsigned int camera2DataCounter = 0;
+  unsigned int camera3DataCounter = 0;
+  std::function<void(const gz::msgs::Image &)> camera1Callback =
+      [&img1, &camera1DataCounter, &imgBufferSize](const gz::msgs::Image & _msg)
+  {
+    memcpy(img1, _msg.data().c_str(), imgBufferSize);
+    camera1DataCounter++;
+  };
+
+  std::function<void(const gz::msgs::Image &)> camera2Callback =
+      [&img2, &camera2DataCounter, &imgBufferSize](const gz::msgs::Image & _msg)
+  {
+    memcpy(img2, _msg.data().c_str(), imgBufferSize);
+    camera2DataCounter++;
+  };
+  std::function<void(const gz::msgs::Image &)> camera3Callback =
+      [&img3, &camera3DataCounter, &imgBufferSize](const gz::msgs::Image & _msg)
+  {
+    memcpy(img3, _msg.data().c_str(), imgBufferSize);
+    camera3DataCounter++;
   };
 
   // Subscribe to the camera topic
   gz::transport::Node node;
   node.Subscribe(infoTopic1, camera1InfoCallback);
   node.Subscribe(infoTopic2, camera2InfoCallback);
+  node.Subscribe(infoTopic3, camera3InfoCallback);
+  node.Subscribe(imgTopic1, camera1Callback);
+  node.Subscribe(imgTopic2, camera2Callback);
+  node.Subscribe(imgTopic3, camera3Callback);
 
   // Wait for a few camera frames
   mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
@@ -267,27 +354,103 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   while (!done && sleep++ < maxSleep)
   {
     std::lock_guard<std::mutex> lock(g_mutex);
-    done = (camera1Counter > 0 && camera2Counter > 0);
+    done = (camera1Counter > 0 && camera2Counter > 0 && camera3Counter > 0 &&
+        camera1DataCounter > 0 && camera2DataCounter > 0 &&
+        camera3DataCounter > 0);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
   // Image size, focal length and optical center
   // Camera sensor without intrinsics tag
-  double error = 1e-1;
-  EXPECT_EQ(camera1Info.width(), 1000u);
-  EXPECT_EQ(camera1Info.height(), 1000u);
-  EXPECT_NEAR(camera1Info.intrinsics().k(0), 863.2297, error);
-  EXPECT_NEAR(camera1Info.intrinsics().k(4), 863.2297, error);
+  double error = 3e-1;
+  EXPECT_EQ(camera1Info.width(), width);
+  EXPECT_EQ(camera1Info.height(), height);
+  EXPECT_NEAR(camera1Info.intrinsics().k(0), 866.23, error);
+  EXPECT_NEAR(camera1Info.intrinsics().k(4), 866.23, error);
   EXPECT_DOUBLE_EQ(camera1Info.intrinsics().k(2), 500);
   EXPECT_DOUBLE_EQ(camera1Info.intrinsics().k(5), 500);
 
   // Camera sensor with intrinsics tag
-  EXPECT_EQ(camera2Info.width(), 1000u);
-  EXPECT_EQ(camera2Info.height(), 1000u);
+  EXPECT_EQ(camera2Info.width(), width);
+  EXPECT_EQ(camera2Info.height(), height);
   EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(0), 866.23);
   EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(4), 866.23);
   EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(2), 500);
   EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(5), 500);
+
+  // Camera sensor with different intrinsics tag
+  EXPECT_EQ(camera3Info.width(), width);
+  EXPECT_EQ(camera3Info.height(), height);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(0), 900);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(4), 900);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(2), 501);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(5), 501);
+
+  unsigned int r1Sum = 0u;
+  unsigned int g1Sum = 0u;
+  unsigned int b1Sum = 0u;
+  unsigned int r2Sum = 0u;
+  unsigned int g2Sum = 0u;
+  unsigned int b2Sum = 0u;
+  unsigned int r3Sum = 0u;
+  unsigned int g3Sum = 0u;
+  unsigned int b3Sum = 0u;
+  unsigned int step = width * bpp;
+
+  // get sum of each color channel
+  // all cameras should just see blue colors
+  for (unsigned int i = 0; i < height; ++i)
+  {
+    for (unsigned int j = 0; j < step; j+=bpp)
+    {
+      unsigned int idx = i * step + j;
+      unsigned int r1 = img1[idx];
+      unsigned int g1 = img1[idx+1];
+      unsigned int b1 = img1[idx+2];
+      r1Sum += r1;
+      g1Sum += g1;
+      b1Sum += b1;
+
+      unsigned int r2 = img2[idx];
+      unsigned int g2 = img2[idx+1];
+      unsigned int b2 = img2[idx+2];
+      r2Sum += r2;
+      g2Sum += g2;
+      b2Sum += b2;
+
+      unsigned int r3 = img3[idx];
+      unsigned int g3 = img3[idx+1];
+      unsigned int b3 = img3[idx+2];
+      r3Sum += r3;
+      g3Sum += g3;
+      b3Sum += b3;
+    }
+  }
+
+  // images from camera1 without intrinsics params and
+  // camera2 with default intrinsic params should be the same
+  EXPECT_EQ(0u, r1Sum);
+  EXPECT_EQ(0u, g1Sum);
+  EXPECT_LT(0u, b1Sum);
+  EXPECT_EQ(r1Sum, r2Sum);
+  EXPECT_EQ(g1Sum, g2Sum);
+  EXPECT_EQ(b1Sum, b2Sum);
+
+  // images from camera2 and camera3 that have different intrinsics params
+  // should be different. Both cameras should still see the blue box but
+  // sum of blue pixels should be slightly different
+  EXPECT_EQ(0u, r3Sum);
+  EXPECT_EQ(0u, g3Sum);
+  EXPECT_LT(0u, b3Sum);
+  EXPECT_EQ(r2Sum, r3Sum);
+  EXPECT_EQ(g2Sum, g3Sum);
+  EXPECT_NE(b2Sum, b3Sum);
+
+  std::cerr << r3Sum << " " << g3Sum << " " << b3Sum << std::endl;
+
+  delete []  img1;
+  delete []  img2;
+  delete []  img3;
 
   // Clean up
   engine->DestroyScene(scene);

--- a/test/sdf/camera_intrinsics.sdf
+++ b/test/sdf/camera_intrinsics.sdf
@@ -7,12 +7,16 @@
         <ignition_frame_id>base_camera</ignition_frame_id>
         <topic>/camera1/image</topic>
         <camera>
-          <horizontal_fov>1.05</horizontal_fov>
+          <horizontal_fov>1.0472</horizontal_fov>
           <image>
             <width>1000</width>
             <height>1000</height>
-            <format>L8</format>
+            <format>R8G8B8</format>
           </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
         </camera>
       </sensor>
       <sensor name="camera_with_intrinsics_tag" type="camera">
@@ -20,12 +24,16 @@
         <ignition_frame_id>base_camera</ignition_frame_id>
         <topic>/camera2/image</topic>
         <camera>
-          <horizontal_fov>1.05</horizontal_fov>
+          <horizontal_fov>1.0472</horizontal_fov>
           <image>
             <width>1000</width>
             <height>1000</height>
-            <format>L8</format>
+            <format>R8G8B8</format>
           </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
           <lens>
             <intrinsics>
               <fx>866.23</fx>
@@ -37,6 +45,33 @@
           </lens>
         </camera>
       </sensor>
+      <sensor name="camera_with_diff_intrinsics_tag" type="camera">
+        <update_rate>10</update_rate>
+        <ignition_frame_id>base_camera</ignition_frame_id>
+        <topic>/camera3/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <intrinsics>
+              <fx>900</fx>
+              <fy>900</fy>
+              <cx>501</cx>
+              <cy>501</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+        </camera>
+      </sensor>
+
     </link>
   </model>
 </sdf>


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gz-sensors/issues/288

## Summary

This PR extends the camera sensor functionality to support custom projection matrix based on input instrinics values. Specifically, it reads the lens `<instrinsics>` params from SDF, builds the projection matrix from the input values using [code ported from Gazebo-classic](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/rendering/Camera.cc#L240-L253), and set the camera to use this custom projection matrix.

Expanded the camera intrinsics integration test to compare image output from cameras with different intrinsics values.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

