### PR TITLE
Renamed ignition_frame_id to gz_frame_id and fix warning

### DIFF
--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -155,9 +155,9 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   sdf::ElementPtr element = _sdf.Element();
   if (element)
   {
-    if (element->HasElement("ignition_frame_id"))
+    if (element->HasElement("gz_frame_id"))
     {
-      this->frame_id = element->Get<std::string>("ignition_frame_id");
+      this->frame_id = element->Get<std::string>("gz_frame_id");
     }
     else
     {

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -161,7 +161,17 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
     }
     else
     {
-      this->frame_id = this->name;
+      // TODO(ahcorde): Remove this deprecation in gz-sensors8
+      if (element->HasElement("ignition_frame_id"))
+      {
+        gzwarn << "The `ignition_frame_id` tag is deprecated. "
+               << "Please use `gz_frame_id` instead." << std::endl;
+        this->frame_id = element->Get<std::string>("ignition_frame_id");
+      }
+      else
+      {
+        this->frame_id = this->name;
+      }
     }
   }
 

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -19,7 +19,7 @@
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
 #endif
-#include <ignition/msgs/performance_sensor_metrics.pb.h>
+#include <gz/msgs/performance_sensor_metrics.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -125,7 +125,7 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
         "/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
-    EXPECT_TRUE(helper.WaitForMessage()) << helper;
+    EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
   }
 
   // test removing sensor

--- a/test/sdf/camera_intrinsics.sdf
+++ b/test/sdf/camera_intrinsics.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_without_intrinsics_tag" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/camera1/image</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>
@@ -17,7 +17,7 @@
       </sensor>
       <sensor name="camera_with_intrinsics_tag" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/camera2/image</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/camera_sensor_builtin.sdf
+++ b/test/sdf/camera_sensor_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera1" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/test/integration/CameraPlugin_imagesWithBuiltinSDF</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/camera_sensor_l16_builtin.sdf
+++ b/test/sdf/camera_sensor_l16_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera1" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/images_l16</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/camera_sensor_l8_l16_builtin.sdf
+++ b/test/sdf/camera_sensor_l8_l16_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_8_bit" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/images_l8</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>
@@ -26,7 +26,7 @@
       </sensor>
       <sensor name="camera_16_bit" type="camera">
         <update_rate>10</update_rate>
-        <ignition_frame_id>base_camera</ignition_frame_id>
+        <gz_frame_id>base_camera</gz_frame_id>
         <topic>/images_l16</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Renamed `ignition_frame_id` to `gz_frame_id` and fix warning

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
