### PR TITLE
Fix compile time warning in Sensors_TEST

### DIFF
--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -19,7 +19,7 @@
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
 #endif
-#include <ignition/msgs/performance_sensor_metrics.pb.h>
+#include <gz/msgs/performance_sensor_metrics.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

# 🦟 Bug fix

## Summary
This PR fixes a compile time warning in ``Sensors_TEST.cc`` due to ign- > gz renaming.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.