### PR TITLE
[backport Fortress] Fix navsat frame id (#295)

### DIFF
--- a/src/NavSatSensor.cc
+++ b/src/NavSatSensor.cc
@@ -158,7 +158,7 @@ bool NavSatSensor::Update(const std::chrono::steady_clock::duration &_now)
 
   msgs::NavSat msg;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
-  msg.set_frame_id(this->Name());
+  msg.set_frame_id(this->FrameId());
 
   // Apply noise
   auto iter = this->dataPtr->noises.find(NAVSAT_HORIZONTAL_POSITION_NOISE);


### PR DESCRIPTION
Signed-off-by: quentinGllmt <quentin.guillemot@free.fr>

# 🎉 Backport

Related to https://github.com/gazebosim/gz-sensors/pull/295

## Summary
Applied `<ignition_frame_id>` tag

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
