### PR TITLE
Disable ogre tests on windows

### DIFF
--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/image.pb.h>
@@ -68,6 +69,14 @@ class CameraSensorTest: public testing::Test,
   // Documentation inherited
   protected: void SetUp() override
   {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
     gz::common::Console::SetVerbosity(4);
   }
 

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/camera_info.pb.h>
@@ -139,6 +140,18 @@ void OnPointCloud(const gz::msgs::PointCloudPacked &_msg)
 class DepthCameraSensorTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
+  }
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 };

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/image.pb.h>
@@ -46,6 +47,14 @@ class DistortionCameraSensorTest: public testing::Test,
   // Documentation inherited
   protected: void SetUp() override
   {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
     gz::common::Console::SetVerbosity(4);
   }
 

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/laserscan.pb.h>
@@ -139,6 +140,19 @@ void pointCb(const gz::msgs::PointCloudPacked &_msg)
 class GpuLidarSensorTest: public testing::Test,
                   public testing::WithParamInterface<const char *>
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
+  }
+
   // Test and verify gpu rays properties setters and getters
   public: void CreateGpuLidar(const std::string &_renderEngine);
 

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/camera_info.pb.h>
@@ -158,6 +159,19 @@ void OnPointCloud(const msgs::PointCloudPacked &_msg)
 class RgbdCameraSensorTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
+  }
+
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 };

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/camera_info.pb.h>
@@ -89,6 +90,19 @@ void OnImage8Bit(const gz::msgs::Image &_msg)
 class ThermalCameraSensorTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
+  }
+
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/boolean.pb.h>
@@ -49,6 +50,14 @@ class TriggeredCameraTest: public testing::Test,
   // Documentation inherited
   protected: void SetUp() override
   {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
     gz::common::Console::SetVerbosity(4);
   }
 

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <gz/msgs/image.pb.h>
@@ -75,6 +76,14 @@ class WideAngleCameraSensorTest: public testing::Test,
   // Documentation inherited
   protected: void SetUp() override
   {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
     gz::common::Console::SetVerbosity(4);
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Toward #284

## Summary
Ogre tests are not working on windows as discussed in #284. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.