### PR TITLE
Bump msgs and transport version in Harmonic

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,9 +1,9 @@
 libgz-cmake3-dev
 libgz-common5-dev
 libgz-math7-dev
-libgz-msgs9-dev
+libgz-msgs10-dev
 libgz-rendering8-dev
 libgz-tools2-dev
-libgz-transport12-dev
+libgz-transport13-dev
 libsdformat13-dev
 xvfb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,8 @@ set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-transport
-gz_find_package(gz-transport12 REQUIRED)
-set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
+gz_find_package(gz-transport13 REQUIRED)
+set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-rendering
@@ -84,8 +84,8 @@ endif()
 
 #--------------------------------------
 # Find gz-msgs
-gz_find_package(gz-msgs9 REQUIRED)
-set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+gz_find_package(gz-msgs10 REQUIRED)
+set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
 
 #--------------------------------------
 # Find SDFormat

--- a/tutorials/thermal_camera.md
+++ b/tutorials/thermal_camera.md
@@ -353,12 +353,12 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(image-listener)
 
 # Find the Gazebo Libraries used directly by the example
-find_package(gz-msgs9 REQUIRED)
-find_package(gz-transport12 REQUIRED)
+find_package(gz-msgs10 REQUIRED)
+find_package(gz-transport13 REQUIRED)
 
 add_executable(${PROJECT_NAME} main.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC gz-msgs9 gz-transport12)
-target_include_directories(${PROJECT_NAME} PUBLIC ${gz_msgs9_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC gz-msgs10 gz-transport13)
+target_include_directories(${PROJECT_NAME} PUBLIC ${gz_msgs10_INCLUDE_DIRS})
 ```
 
 Although most of the code above is described in the comments, let's go over the key points again:


### PR DESCRIPTION
# 🎉 New feature

## Summary

Bumping to use the new msgs and transport versions in Harmonic, msgs10 and transport13

https://github.com/gazebo-tooling/release-tools/issues/878

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

