### PR TITLE
Added trigger to BoundingBoxCamera

### DIFF
--- a/include/gz/sensors/BoundingBoxCameraSensor.hh
+++ b/include/gz/sensors/BoundingBoxCameraSensor.hh
@@ -105,7 +105,7 @@ namespace gz
 
       /// \brief Callback for triggered subscription
       /// \param[in] _msg Boolean message
-      private: virtual void OnTrigger(const gz::msgs::Boolean &/*_msg*/) override;
+      private: void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/gz/sensors/BoundingBoxCameraSensor.hh
+++ b/include/gz/sensors/BoundingBoxCameraSensor.hh
@@ -103,6 +103,10 @@ namespace gz
       /// \return True on success.
       private: bool CreateCamera();
 
+      /// \brief Callback for triggered subscription
+      /// \param[in] _msg Boolean message
+      private: virtual void OnTrigger(const gz::msgs::Boolean &/*_msg*/) override;
+
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <gz/msgs/image.pb.h>
+#include <gz/msgs/boolean.pb.h>
 
 #include <sdf/sdf.hh>
 
@@ -174,6 +175,10 @@ namespace gz
       /// the Manager.
       /// \param[in] _scene Pointer to the new scene.
       private: void OnSceneChange(gz::rendering::ScenePtr /*_scene*/);
+
+      /// \brief Callback for triggered subscription
+      /// \param[in] _msg Boolean message
+      private: virtual void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -178,7 +178,7 @@ namespace gz
 
       /// \brief Callback for triggered subscription
       /// \param[in] _msg Boolean message
-      private: virtual void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
+      private: void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -21,8 +21,8 @@
 #include <memory>
 #include <string>
 
-#include <gz/msgs/image.pb.h>
 #include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/image.pb.h>
 
 #include <sdf/sdf.hh>
 

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -39,6 +39,10 @@ using namespace sensors;
 
 class gz::sensors::BoundingBoxCameraSensorPrivate
 {
+  /// \brief Callback for triggered subscription
+  /// \param[in] _msg Boolean message
+  public: void OnTrigger(const msgs::Boolean &_msg);
+
   /// \brief Save an image of rgb camera
   public: void SaveImage();
 
@@ -84,6 +88,15 @@ class gz::sensors::BoundingBoxCameraSensorPrivate
 
   /// \brief Just a mutex for thread safety
   public: std::mutex mutex;
+
+  /// \brief True if camera is triggered by a topic
+  public: bool isTriggeredCamera = false;
+
+  /// \brief True if camera has been triggered by a topic
+  public: bool isTriggered = false;
+
+  /// \brief Topic for camera trigger
+  public: std::string triggerTopic = "";
 
   /// \brief BoundingBoxes type
   public: rendering::BoundingBoxType type
@@ -216,6 +229,32 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
 
   gzdbg << "Bounding boxes for [" << this->Name() << "] advertised on ["
     << topicBoundingBoxes << std::endl;
+
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    if (!_sdf.CameraSensor()->TriggerTopic().empty())
+    {
+      this->dataPtr->triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    }
+    else
+    {
+      this->dataPtr->triggerTopic =
+          transport::TopicUtils::AsValidTopic(this->dataPtr->triggerTopic);
+
+      if (this->dataPtr->triggerTopic.empty())
+      {
+        gzerr << "Invalid trigger topic name" << std::endl;
+        return false;
+      }
+    }
+
+    this->dataPtr->node.Subscribe(this->dataPtr->triggerTopic,
+        &BoundingBoxCameraSensorPrivate::OnTrigger, this->dataPtr.get());
+
+    gzdbg << "Camera trigger messages for [" << this->Name() << "] subscribed"
+           << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
+    this->dataPtr->isTriggeredCamera = true;
+  }
 
   if (!this->AdvertiseInfo())
     return false;
@@ -390,6 +429,13 @@ bool BoundingBoxCameraSensor::Update(
     this->PublishInfo(_now);
   }
 
+  // render only if necessary
+  if (this->dataPtr->isTriggeredCamera &&
+      !this->dataPtr->isTriggered)
+  {
+    return true;
+  }
+
   // don't render if there are no subscribers nor saving
   if (!this->dataPtr->imagePublisher.HasConnections() &&
     !this->dataPtr->boxesPublisher.HasConnections() &&
@@ -528,6 +574,11 @@ bool BoundingBoxCameraSensor::Update(
     ++this->dataPtr->saveCounter;
   }
 
+  if (this->dataPtr->isTriggeredCamera)
+  {
+    return this->dataPtr->isTriggered = false;
+  }
+
   return true;
 }
 
@@ -541,6 +592,13 @@ unsigned int BoundingBoxCameraSensor::ImageHeight() const
 unsigned int BoundingBoxCameraSensor::ImageWidth() const
 {
   return this->dataPtr->rgbCamera->ImageWidth();
+}
+
+//////////////////////////////////////////////////
+void BoundingBoxCameraSensorPrivate::OnTrigger(const gz::msgs::Boolean &/*_msg*/)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+  this->isTriggered = true;
 }
 
 //////////////////////////////////////////////////

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -239,7 +239,8 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
 
       if (this->dataPtr->triggerTopic.empty())
       {
-        gzerr << "Invalid trigger topic name [" << this->dataPtr->triggerTopic << "]" << std::endl;
+        gzerr << "Invalid trigger topic name [" << 
+        this->dataPtr->triggerTopic << "]" << std::endl;
         return false;
       }
     }

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -39,10 +39,6 @@ using namespace sensors;
 
 class gz::sensors::BoundingBoxCameraSensorPrivate
 {
-  /// \brief Callback for triggered subscription
-  /// \param[in] _msg Boolean message
-  public: void OnTrigger(const msgs::Boolean &_msg);
-
   /// \brief Save an image of rgb camera
   public: void SaveImage();
 
@@ -249,7 +245,7 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
     }
 
     this->dataPtr->node.Subscribe(this->dataPtr->triggerTopic,
-        &BoundingBoxCameraSensorPrivate::OnTrigger, this->dataPtr.get());
+        &BoundingBoxCameraSensor::OnTrigger, this);
 
     gzdbg << "Camera trigger messages for [" << this->Name() << "] subscribed"
            << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
@@ -595,10 +591,10 @@ unsigned int BoundingBoxCameraSensor::ImageWidth() const
 }
 
 //////////////////////////////////////////////////
-void BoundingBoxCameraSensorPrivate::OnTrigger(const gz::msgs::Boolean &/*_msg*/)
+void BoundingBoxCameraSensor::OnTrigger(const gz::msgs::Boolean &/*_msg*/)
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
-  this->isTriggered = true;
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+  this->dataPtr->isTriggered = true;
 }
 
 //////////////////////////////////////////////////

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -86,13 +86,13 @@ class gz::sensors::BoundingBoxCameraSensorPrivate
   public: std::mutex mutex;
 
   /// \brief True if camera is triggered by a topic
-  public: bool isTriggeredCamera = false;
+  public: bool isTriggeredCamera{false};
 
   /// \brief True if camera has been triggered by a topic
-  public: bool isTriggered = false;
+  public: bool isTriggered{false};
 
   /// \brief Topic for camera trigger
-  public: std::string triggerTopic = "";
+  public: std::string triggerTopic{""};
 
   /// \brief BoundingBoxes type
   public: rendering::BoundingBoxType type
@@ -239,7 +239,7 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
 
       if (this->dataPtr->triggerTopic.empty())
       {
-        gzerr << "Invalid trigger topic name" << std::endl;
+        gzerr << "Invalid trigger topic name [" << this->dataPtr->triggerTopic << "]" << std::endl;
         return false;
       }
     }
@@ -248,7 +248,7 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
         &BoundingBoxCameraSensor::OnTrigger, this);
 
     gzdbg << "Camera trigger messages for [" << this->Name() << "] subscribed"
-           << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
+          << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
     this->dataPtr->isTriggeredCamera = true;
   }
 

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -239,7 +239,7 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
 
       if (this->dataPtr->triggerTopic.empty())
       {
-        gzerr << "Invalid trigger topic name [" << 
+        gzerr << "Invalid trigger topic name [" <<
         this->dataPtr->triggerTopic << "]" << std::endl;
         return false;
       }

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -49,10 +49,6 @@ using namespace sensors;
 /// \brief Private data for CameraSensor
 class gz::sensors::CameraSensorPrivate
 {
-  /// \brief Callback for triggered subscription
-  /// \param[in] _msg Boolean message
-  public: void OnTrigger(const msgs::Boolean &_msg);
-
   /// \brief Save an image
   /// \param[in] _data the image data to be saved
   /// \param[in] _width width of image in pixels
@@ -459,7 +455,7 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
     }
 
     this->dataPtr->node.Subscribe(this->dataPtr->triggerTopic,
-        &CameraSensorPrivate::OnTrigger, this->dataPtr.get());
+        &CameraSensor::OnTrigger, this);
 
     gzdbg << "Camera trigger messages for [" << this->Name() << "] subscribed"
            << " on [" << this->dataPtr->triggerTopic << "]" << std::endl;
@@ -657,10 +653,10 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
 }
 
 //////////////////////////////////////////////////
-void CameraSensorPrivate::OnTrigger(const gz::msgs::Boolean &/*_msg*/)
+void CameraSensor::OnTrigger(const gz::msgs::Boolean &/*_msg*/)
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
-  this->isTriggered = true;
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+  this->dataPtr->isTriggered = true;
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -11,6 +11,7 @@ set(dri_tests
   thermal_camera.cc
   triggered_camera.cc
   wide_angle_camera.cc
+  triggered_boundingbox_camera.cc
 )
 
 set(tests

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Open Source Robotics Foundation
+ * Copyright (C) 2023 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -156,7 +156,7 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
 
   std::string type = sdfSensor.TypeStr();
   EXPECT_EQ(type, "boundingbox_camera");
-  
+
   gz::sensors::BoundingBoxCameraSensor *sensor =
       mgr.CreateSensor<gz::sensors::BoundingBoxCameraSensor>(sdfSensor);
   ASSERT_NE(sensor, nullptr);
@@ -217,7 +217,7 @@ TEST_P(TriggeredBoundingBoxCameraTest, BoxesWithBuiltinSDF)
   BoxesWithBuiltinSDF(GetParam());
 }
 
-INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor, 
+INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor,
     TriggeredBoundingBoxCameraTest,
     RENDER_ENGINE_VALUES, gz::rendering::PrintToStringParam());
 

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -112,7 +112,8 @@ void BuildScene(gz::rendering::ScenePtr _scene)
   root->AddChild(box2);
 }
 
-void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(const std::string &_renderEngine)
+void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
+  const std::string &_renderEngine)
 {
   std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
       "sdf", "triggered_boundingbox_camera_sensor_builtin.sdf");
@@ -169,13 +170,13 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(const std::string &_ren
   // subscribe to the BoundingBox camera topic
   gz::transport::Node node;
   std::string boxTopic =
-      "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF";
+      "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF";
   node.Subscribe(boxTopic, &OnNewBoundingBoxes);
 
   // we should not have image before trigger
   {
     std::string imageTopic =
-        "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF_image";
+        "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF_image";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
     EXPECT_FALSE(helper.WaitForMessage(1s)) << helper;
@@ -186,7 +187,7 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(const std::string &_ren
 
   // trigger camera through topic
   std::string triggerTopic =
-      "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF/trigger";
+      "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF/trigger";
 
   auto pub = node.Advertise<gz::msgs::Boolean>(triggerTopic);
   gz::msgs::Boolean msg;
@@ -196,7 +197,7 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(const std::string &_ren
   // we should receive images and boxes after trigger
   {
     std::string imageTopic =
-        "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF_image";
+        "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF_image";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
@@ -216,7 +217,8 @@ TEST_P(TriggeredBoundingBoxCameraTest, BoxesWithBuiltinSDF)
   BoxesWithBuiltinSDF(GetParam());
 }
 
-INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor, TriggeredBoundingBoxCameraTest,
+INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor, 
+    TriggeredBoundingBoxCameraTest,
     RENDER_ENGINE_VALUES, gz::rendering::PrintToStringParam());
 
 //////////////////////////////////////////////////

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/image.pb.h>
+
+#include <gz/common/Console.hh>
+#include <gz/common/Filesystem.hh>
+#include <gz/sensors/BoundingBoxCameraSensor.hh>
+#include <gz/sensors/Manager.hh>
+
+// TODO(louise) Remove these pragmas once gz-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+
+#include "test_config.hh"  // NOLINT(build/include)
+#include "TransportTestTools.hh"
+
+using namespace std::chrono_literals;
+
+class TriggeredBoundingBoxCameraTest: public testing::Test,
+  public testing::WithParamInterface<const char *>
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    // Disable Ogre tests on windows. See
+    // https://github.com/gazebosim/gz-sensors/issues/284
+#ifdef _WIN32
+    if (strcmp(GetParam(), "ogre") == 0)
+    {
+      GTEST_SKIP() << "Ogre tests disabled on windows. See #284.";
+    }
+#endif
+    gz::common::Console::SetVerbosity(4);
+  }
+
+  // Create a BoundingBox Camera sensor from a SDF and gets a boxes message
+  public: void BoxesWithBuiltinSDF(const std::string &_renderEngine);
+
+};
+
+/// \brief mutex for thread safety
+std::mutex g_mutex;
+
+/// \brief bounding boxes from the camera
+std::vector<gz::msgs::AnnotatedAxisAligned2DBox> g_boxes;
+
+/// \brief callback to receive 2d boxes from the camera
+void OnNewBoundingBoxes(const gz::msgs::AnnotatedAxisAligned2DBox_V &_boxes)
+{
+  g_mutex.lock();
+  g_boxes.clear();
+
+  int size = _boxes.annotated_box_size();
+  for (int i = 0; i < size; ++i)
+  {
+    auto annotated_box = _boxes.annotated_box(i);
+    g_boxes.push_back(annotated_box);
+  }
+  g_mutex.unlock();
+}
+
+/// \brief Build a scene with 2 visible boxes
+void BuildScene(gz::rendering::ScenePtr _scene)
+{
+  gz::math::Vector3d box1Position(1, -1, 0);
+  gz::math::Vector3d box2Position(1, 1, 0);
+
+  gz::rendering::VisualPtr root = _scene->RootVisual();
+
+  gz::rendering::VisualPtr box1 = _scene->CreateVisual();
+  box1->AddGeometry(_scene->CreateBox());
+  box1->SetOrigin(0.0, 0.0, 0.0);
+  box1->SetLocalPosition(box1Position);
+  box1->SetLocalRotation(0, 0, 0);
+  box1->SetUserData("label", 1);
+  root->AddChild(box1);
+
+  gz::rendering::VisualPtr box2 = _scene->CreateVisual();
+  box2->AddGeometry(_scene->CreateBox());
+  box2->SetOrigin(0.0, 0.0, 0.0);
+  box2->SetLocalPosition(box2Position);
+  box2->SetLocalRotation(0, 0, 0);
+  box2->SetUserData("label", 2);
+  root->AddChild(box2);
+}
+
+void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "triggered_boundingbox_camera_sensor_builtin.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+    // Skip unsupported engines
+  if (_renderEngine != "ogre2")
+  {
+    gzdbg << "Engine '" << _renderEngine
+           << "' doesn't support bounding box cameras" << std::endl;
+    return;
+  }
+
+  // Setup gz-rendering with an empty scene
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+           << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+  BuildScene(scene);
+
+  gz::sensors::Manager mgr;
+
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(sensorPtr);
+
+  std::string type = sdfSensor.TypeStr();
+  EXPECT_EQ(type, "boundingbox_camera");
+  
+  gz::sensors::BoundingBoxCameraSensor *sensor =
+      mgr.CreateSensor<gz::sensors::BoundingBoxCameraSensor>(sdfSensor);
+  ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
+  sensor->SetScene(scene);
+
+  EXPECT_EQ(320u, sensor->ImageWidth());
+  EXPECT_EQ(240u, sensor->ImageHeight());
+  EXPECT_EQ(true, sdfSensor.CameraSensor()->Triggered());
+
+  // subscribe to the BoundingBox camera topic
+  gz::transport::Node node;
+  std::string boxTopic =
+      "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF";
+  node.Subscribe(boxTopic, &OnNewBoundingBoxes);
+
+  // we should not have image before trigger
+  {
+    std::string imageTopic =
+        "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF_image";
+    WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    EXPECT_FALSE(helper.WaitForMessage(1s)) << helper;
+    g_mutex.lock();
+    EXPECT_EQ(g_boxes.size(), size_t(0));
+    g_mutex.unlock();
+  }
+
+  // trigger camera through topic
+  std::string triggerTopic =
+      "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF/trigger";
+
+  auto pub = node.Advertise<gz::msgs::Boolean>(triggerTopic);
+  gz::msgs::Boolean msg;
+  msg.set_data(true);
+  pub.Publish(msg);
+
+  // we should receive images and boxes after trigger
+  {
+    std::string imageTopic =
+        "/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF_image";
+    WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
+    g_mutex.lock();
+    EXPECT_EQ(g_boxes.size(), size_t(2));
+    g_mutex.unlock();
+  }
+
+  // Clean up
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(TriggeredBoundingBoxCameraTest, BoxesWithBuiltinSDF)
+{
+  BoxesWithBuiltinSDF(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor, TriggeredBoundingBoxCameraTest,
+    RENDER_ENGINE_VALUES, gz::rendering::PrintToStringParam());
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  gz::common::Console::SetVerbosity(4);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/sdf/triggered_boundingbox_camera_sensor_builtin.sdf
+++ b/test/sdf/triggered_boundingbox_camera_sensor_builtin.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="boundingbox_camera" type="boundingbox_camera">
+        <update_rate>10</update_rate>
+        <topic>/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF</topic>
+        <camera>
+          <triggered>true</triggered>
+          <trigger_topic>/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF/trigger</trigger_topic>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>320</width>
+            <height>240</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/sdf/triggered_boundingbox_camera_sensor_builtin.sdf
+++ b/test/sdf/triggered_boundingbox_camera_sensor_builtin.sdf
@@ -4,10 +4,10 @@
     <link name="link1">
       <sensor name="boundingbox_camera" type="boundingbox_camera">
         <update_rate>10</update_rate>
-        <topic>/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF</topic>
+        <topic>/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF</topic>
         <camera>
           <triggered>true</triggered>
-          <trigger_topic>/test/integration/TriggeredBoundingBoxCameraPlugin_imagesWithBuiltinSDF/trigger</trigger_topic>
+          <trigger_topic>/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF/trigger</trigger_topic>
           <horizontal_fov>1.05</horizontal_fov>
           <image>
             <width>320</width>


### PR DESCRIPTION
Signed-off-by: Valentina Vasco <vale88.vasco@gmail.com>
# 🎉 New feature

Closes #321

## Summary

This adds the possibility to trigger a BoundingBoxCamera.

## Test it

Checkout the branch https://github.com/vvasco/gz-sensors/tree/triggered_bounding_box_camera and run the `INTEGRATION_triggered_boundingbox_camera`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

