### PR TITLE
Fix flaky  bounding box camera test

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -427,10 +427,13 @@ bool BoundingBoxCameraSensor::Update(
   }
 
   // render only if necessary
-  if (this->dataPtr->isTriggeredCamera &&
-      !this->dataPtr->isTriggered)
   {
-    return true;
+    std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+    if (this->dataPtr->isTriggeredCamera &&
+        !this->dataPtr->isTriggered)
+    {
+      return true;
+    }
   }
 
   // don't render if there are no subscribers nor saving

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -193,12 +193,13 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
   gz::msgs::Boolean msg;
   msg.set_data(true);
   pub.Publish(msg);
+  // sleep to wait for trigger msg to be received before calling mgr.RunOnce
+  std::this_thread::sleep_for(2s);
 
   // we should receive images and boxes after trigger
   {
-    std::string imageTopic =
-        "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF_image";
-    WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
+    WaitForMessageTestHelper<gz::msgs::AnnotatedAxisAligned2DBox_V>
+        helper(boxTopic);
     mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
     g_mutex.lock();


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #328

## Summary

Fixes flaky bounding box camera test due to timing / race condition. This PR fixes the test by making sure:
1. we allow time for trigger msg to arrive to bounding box camera
2. make sure msgs are received on the box topic (instead of image topic) which is what the tests is checking
3. add mutex to protect the `isTriggered` variable.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

