### PR TITLE
populate the covariance fields using the noise models

### DIFF
--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -268,7 +268,9 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
       GaussianNoiseModelPtr gaussian =
         std::dynamic_pointer_cast<GaussianNoiseModel>(
             this->dataPtr->noises[noiseType]);
-      return (float) (gaussian->StdDev() * gaussian->StdDev());
+      if (gaussian) {
+        return static_cast<float>(gaussian->StdDev() * gaussian->StdDev());
+      }
     }
     return 0.001f;
   };

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -286,9 +286,9 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
         4, getCov(GYROSCOPE_Y_NOISE_RAD_S));
     msg.mutable_angular_velocity_covariance()->set_data(
         8, getCov(GYROSCOPE_Z_NOISE_RAD_S));
-    msg.mutable_orientation_covariance()->set_data( 0, 0.001);
-    msg.mutable_orientation_covariance()->set_data( 4, 0.001);
-    msg.mutable_orientation_covariance()->set_data( 8, 0.001);
+    msg.mutable_orientation_covariance()->set_data(0, 0.001);
+    msg.mutable_orientation_covariance()->set_data(4, 0.001);
+    msg.mutable_orientation_covariance()->set_data(8, 0.001);
   }
 
   if (this->dataPtr->orientationEnabled)

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -272,7 +272,7 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
         return static_cast<float>(gaussian->StdDev() * gaussian->StdDev());
       }
     }
-    return 0.001f;
+    return 0.0f;
   };
 
   {
@@ -288,9 +288,9 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
         4, getCov(GYROSCOPE_Y_NOISE_RAD_S));
     msg.mutable_angular_velocity_covariance()->set_data(
         8, getCov(GYROSCOPE_Z_NOISE_RAD_S));
-    msg.mutable_orientation_covariance()->set_data(0, 0.001);
-    msg.mutable_orientation_covariance()->set_data(4, 0.001);
-    msg.mutable_orientation_covariance()->set_data(8, 0.001);
+    msg.mutable_orientation_covariance()->set_data(0, 0.0);
+    msg.mutable_orientation_covariance()->set_data(4, 0.0);
+    msg.mutable_orientation_covariance()->set_data(8, 0.0);
   }
 
   if (this->dataPtr->orientationEnabled)


### PR DESCRIPTION
# 🎉 New feature

This PR fills the imu covariance field

## Summary

This PR depends on this one: https://github.com/gazebosim/gz-msgs/pull/333

The published imu message is missing the covariance fields for linear_acceleration, angular_velocity and orientation_covariance. Those can be very useful when bridging between gz and ros.

Note: a Pr on ros_gz to update the convertion to ros is coming


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
