### PR TITLE
Generate default trigger topic name if empty

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -235,7 +235,8 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
     else
     {
       this->dataPtr->triggerTopic =
-          transport::TopicUtils::AsValidTopic(this->dataPtr->triggerTopic);
+          transport::TopicUtils::AsValidTopic(
+          this->Topic() + "/trigger");
 
       if (this->dataPtr->triggerTopic.empty())
       {

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -454,7 +454,8 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
     else
     {
       this->dataPtr->triggerTopic =
-          transport::TopicUtils::AsValidTopic(this->dataPtr->triggerTopic);
+          transport::TopicUtils::AsValidTopic(
+          this->Topic() + "/trigger");
 
       if (this->dataPtr->triggerTopic.empty())
       {

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -64,6 +64,8 @@ class TriggeredBoundingBoxCameraTest: public testing::Test,
   // Create a BoundingBox Camera sensor from a SDF and gets a boxes message
   public: void BoxesWithBuiltinSDF(const std::string &_renderEngine);
 
+  // Create a BoundingBox Camera sensor from a SDF with empty trigger topic
+  public: void EmptyTriggerTopic(const std::string &_renderEngine);
 };
 
 /// \brief mutex for thread safety
@@ -213,10 +215,100 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
   gz::rendering::unloadEngine(engine->Name());
 }
 
+void TriggeredBoundingBoxCameraTest::EmptyTriggerTopic(
+  const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "triggered_boundingbox_camera_sensor_topic_builtin.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+    // Skip unsupported engines
+  if (_renderEngine != "ogre2")
+  {
+    gzdbg << "Engine '" << _renderEngine
+           << "' doesn't support bounding box cameras" << std::endl;
+    return;
+  }
+
+  // Setup gz-rendering with an empty scene
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+           << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+  BuildScene(scene);
+
+  gz::sensors::Manager mgr;
+
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(sensorPtr);
+
+  std::string type = sdfSensor.TypeStr();
+  EXPECT_EQ(type, "boundingbox_camera");
+
+  gz::sensors::BoundingBoxCameraSensor *sensor =
+      mgr.CreateSensor<gz::sensors::BoundingBoxCameraSensor>(sdfSensor);
+  ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
+  sensor->SetScene(scene);
+
+  // trigger camera through topic
+  std::string triggerTopic =
+      "/test/integration/triggered_bbcamera/trigger";
+
+  gz::transport::Node node;
+  auto pub = node.Advertise<gz::msgs::Boolean>(triggerTopic);
+  gz::msgs::Boolean msg;
+  msg.set_data(true);
+  pub.Publish(msg);
+  // sleep to wait for trigger msg to be received before calling mgr.RunOnce
+  std::this_thread::sleep_for(2s);
+
+  // we should receive images and boxes after trigger
+  {
+    std::string boxTopic =
+        "/test/integration/triggered_bbcamera";
+    WaitForMessageTestHelper<gz::msgs::AnnotatedAxisAligned2DBox_V>
+        helper(boxTopic);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
+    g_mutex.lock();
+    EXPECT_EQ(g_boxes.size(), size_t(2));
+    g_mutex.unlock();
+  }
+
+  // Clean up
+  mgr.Remove(sensor->Id());
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
 //////////////////////////////////////////////////
 TEST_P(TriggeredBoundingBoxCameraTest, BoxesWithBuiltinSDF)
 {
   BoxesWithBuiltinSDF(GetParam());
+}
+
+
+
+//////////////////////////////////////////////////
+TEST_P(TriggeredBoundingBoxCameraTest, EmptyTriggerTopic)
+{
+  EmptyTriggerTopic(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(BoundingBoxCameraSensor,

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -303,8 +303,6 @@ TEST_P(TriggeredBoundingBoxCameraTest, BoxesWithBuiltinSDF)
   BoxesWithBuiltinSDF(GetParam());
 }
 
-
-
 //////////////////////////////////////////////////
 TEST_P(TriggeredBoundingBoxCameraTest, EmptyTriggerTopic)
 {

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -131,6 +131,9 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   msg.set_data(true);
   pub.Publish(msg);
 
+  // sleep to wait for trigger msg to be received before calling mgr.RunOnce
+  std::this_thread::sleep_for(2s);
+
   // check camera image after trigger
   {
     std::string imageTopic =

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -63,6 +63,9 @@ class TriggeredCameraTest: public testing::Test,
 
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+
+  // Create a Camera sensor from a SDF with empty trigger topic
+  public: void EmptyTriggerTopic(const std::string &_renderEngine);
 };
 
 void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
@@ -154,11 +157,82 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   gz::rendering::unloadEngine(engine->Name());
 }
 
+void TriggeredCameraTest::EmptyTriggerTopic(const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "triggered_camera_sensor_topic_builtin.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+  // Setup gz-rendering with an empty scene
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+           << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  gz::sensors::Manager mgr;
+
+  gz::sensors::CameraSensor *sensor =
+      mgr.CreateSensor<gz::sensors::CameraSensor>(sensorPtr);
+  ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->HasConnections());
+  sensor->SetScene(scene);
+
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(sensorPtr);
+  EXPECT_EQ(true, sdfSensor.CameraSensor()->Triggered());
+
+  // trigger camera through default generated topic
+  gz::transport::Node triggerNode;
+  std::string triggerTopic =
+      "/test/integration/triggered_camera/trigger";
+
+  auto pub = triggerNode.Advertise<gz::msgs::Boolean>(triggerTopic);
+  gz::msgs::Boolean msg;
+  msg.set_data(true);
+  pub.Publish(msg);
+
+  // check camera image after trigger
+  {
+    std::string imageTopic =
+        "/test/integration/triggered_camera";
+    WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
+  }
+
+  // Clean up
+  auto sensorId = sensor->Id();
+  EXPECT_TRUE(mgr.Remove(sensorId));
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
 //////////////////////////////////////////////////
 TEST_P(TriggeredCameraTest, ImagesWithBuiltinSDF)
 {
   gz::common::Console::SetVerbosity(4);
   ImagesWithBuiltinSDF(GetParam());
+}
+
+//////////////////////////////////////////////////
+TEST_P(TriggeredCameraTest, EmptyTriggerTopic)
+{
+  gz::common::Console::SetVerbosity(4);
+  EmptyTriggerTopic(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(CameraSensor, TriggeredCameraTest,

--- a/test/sdf/triggered_boundingbox_camera_sensor_topic_builtin.sdf
+++ b/test/sdf/triggered_boundingbox_camera_sensor_topic_builtin.sdf
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="boundingbox_camera" type="boundingbox_camera">
+        <update_rate>10</update_rate>
+        <topic>/test/integration/triggered_bbcamera</topic>
+        <camera>
+          <triggered>true</triggered>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>320</width>
+            <height>240</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/sdf/triggered_camera_sensor_topic_builtin.sdf
+++ b/test/sdf/triggered_camera_sensor_topic_builtin.sdf
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera1" type="camera">
+        <update_rate>10</update_rate>
+        <topic>/test/integration/triggered_camera</topic>
+        <camera>
+          <triggered>true</triggered>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>256</width>
+            <height>257</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Currently the sensor manager will fail to create a triggered camera sensor if the `<trigger_topic>` is unspecified / empty, the sensor. This PR fixes the problem by generating a default value for the `<trigger_topic>` if it's empty.

You can test with the `triggered_camera_sensor.sdf` world in gazebo. Comment out the [<trigger_topic>](https://github.com/gazebosim/gz-sim/blob/gz-sim7/examples/worlds/triggered_camera_sensor.sdf#L296) line in the world sdf file and launch gz sim:

```sh
gz sim -v 4 triggered_camera_sensor.sdf
``` 

Before the changes in this PR, you'll get these error msgs:

```sh
[Err] [CameraSensor.cc:461] Invalid trigger topic name
[Err] [SensorFactory.hh:105] Failed to load sensor [camera::link::camera] of type[camera]
[Err] [Manager.hh:80] Failed to create sensor.
[Err] [Sensors.cc:844] Failed to create sensor [camera::link::camera].
[Err] [SceneManager.cc:1755] Unable to find sensor []
[Err] [RenderUtil.cc:1319] Failed to create sensor []
```

After the changes, the error messages should be gone and you should be able to publish a trigger message to see the image

```sh
gz topic -t /camera/trigger -m Boolean -p "data: true" -n 1
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

