### PR TITLE
Fix flaky triggered camera test

### DIFF
--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -208,6 +208,9 @@ void TriggeredCameraTest::EmptyTriggerTopic(const std::string &_renderEngine)
   msg.set_data(true);
   pub.Publish(msg);
 
+  // sleep to wait for trigger msg to be received before calling mgr.RunOnce
+  std::this_thread::sleep_for(2s);
+
   // check camera image after trigger
   {
     std::string imageTopic =


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sensors/issues/345

## Summary

Test fails because the sensor tries to process the trigger message before it actually receives the message.
The fix is to wait (sleep) a couple of seconds before processing the message. The [same logic is done](https://github.com/gazebosim/gz-sensors/blob/82f0e448b507c740dce499d9b4ed44b8f80151e3/test/integration/triggered_camera.cc#L134-L135) in the other triggered camera test.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

