### PR TITLE
Fix finding GzProtobuf to support version 4.23.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-set(REQ_PROTOBUF_VER 3)
 ign_find_package(IgnProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  PRETTY Protobuf)
 


### PR DESCRIPTION

# 🎉 New feature

GzProtobuf: Do not require version 3 do support Protobuf 4.23.2 (23.2)

## Summary

The motivation is similar to https://github.com/gazebosim/gz-msgs/pull/346 . For some reason in the case of this library there are no linking problem at build time, but rather runtime ABI issues: https://github.com/conda-forge/gz-sensors-feedstock/pull/13#issuecomment-1579408286 .

## Test it

Install protobuf 23.2 and run the tests (I guess the only way to do it easily for now is to use conda-forge, see https://repology.org/project/protobuf/versions .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
