### PR TITLE
Backport #351: Support protobuf >= 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-set(REQ_PROTOBUF_VER 3)
 ign_find_package(IgnProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  PRETTY Protobuf)
 


### PR DESCRIPTION
Backport #351 to fix finding the newest versions of protobuf, which is now in homebrew-core. Use rebase-and-merge.