### PR TITLE
Fix CameraSensor to check if element is null before access

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -257,7 +257,8 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetAspectRatio(static_cast<double>(width)/height);
   this->dataPtr->camera->SetHFOV(angle);
 
-  if (cameraSdf->Element() != nullptr && cameraSdf->Element()->HasElement("distortion")) {
+  if (cameraSdf->Element() != nullptr &&
+      cameraSdf->Element()->HasElement("distortion")) {
     this->dataPtr->distortion =
         ImageDistortionFactory::NewDistortionModel(*cameraSdf, "camera");
     this->dataPtr->distortion->Load(*cameraSdf);

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -257,7 +257,7 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetAspectRatio(static_cast<double>(width)/height);
   this->dataPtr->camera->SetHFOV(angle);
 
-  if (cameraSdf->Element()->HasElement("distortion")) {
+  if (cameraSdf->Element() != nullptr && cameraSdf->Element()->HasElement("distortion")) {
     this->dataPtr->distortion =
         ImageDistortionFactory::NewDistortionModel(*cameraSdf, "camera");
     this->dataPtr->distortion->Load(*cameraSdf);


### PR DESCRIPTION
I was try to use the `example/save_image` which segfaults during execution. In the CameraSensor it was failing to check if the sensor element was not null before accessing it. 