### PR TITLE
Update air sensor with air_speed.proto

### DIFF
--- a/src/AirSpeedSensor.cc
+++ b/src/AirSpeedSensor.cc
@@ -20,7 +20,7 @@
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
 #endif
-#include <gz/msgs/air_speed_sensor.pb.h>
+#include <gz/msgs/air_speed.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif
@@ -113,7 +113,7 @@ bool AirSpeedSensor::Load(const sdf::Sensor &_sdf)
     this->SetTopic("/air_speed");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<msgs::AirSpeedSensor>(
+      this->dataPtr->node.Advertise<msgs::AirSpeed>(
       this->Topic());
 
   if (!this->dataPtr->pub)
@@ -155,7 +155,7 @@ bool AirSpeedSensor::Update(
     return false;
   }
 
-  msgs::AirSpeedSensor msg;
+  msgs::AirSpeed msg;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
@@ -185,7 +185,6 @@ bool AirSpeedSensor::Update(
     diff_pressure =
       this->dataPtr->noises[AIR_SPEED_NOISE_PASCALS]->Apply(
           diff_pressure);
-    msg.mutable_pressure_noise()->set_type(msgs::SensorNoise::GAUSSIAN);
   }
 
   msg.set_diff_pressure(diff_pressure * 100.0f);

--- a/test/integration/air_speed.cc
+++ b/test/integration/air_speed.cc
@@ -184,7 +184,7 @@ TEST_F(AirSpeedSensorTest, SensorReadings)
       gz::math::Pose3d(0, 0, 1.5, 0, 0, 0) * sensorNoise->Pose());
 
   // verify msg received on the topic
-  WaitForMessageTestHelper<gz::msgs::AirSpeedSensor> msgHelper(topic);
+  WaitForMessageTestHelper<gz::msgs::AirSpeed> msgHelper(topic);
   EXPECT_TRUE(sensor->HasConnections());
   sensor->Update(std::chrono::steady_clock::duration(std::chrono::seconds(1)));
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
@@ -195,7 +195,7 @@ TEST_F(AirSpeedSensorTest, SensorReadings)
   EXPECT_DOUBLE_EQ(288.1369934082031, msg.temperature());
 
   // verify msg with noise received on the topic
-  WaitForMessageTestHelper<gz::msgs::AirSpeedSensor>
+  WaitForMessageTestHelper<gz::msgs::AirSpeed>
     msgHelperNoise(topicNoise);
   sensorNoise->Update(std::chrono::steady_clock::duration(
       std::chrono::seconds(1)), false);


### PR DESCRIPTION
# 🎉 New feature

## Summary

Required https://github.com/gazebosim/gz-msgs/pull/365

Added `air_speed.proto` msgs. I was using `air_speed_sensor.proto` in older version to avoid breaking ABI, in `main` we can do things properly

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

