### PR TITLE
Tests need to include message types they are using

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -19,7 +19,9 @@
 
 #include <gz/msgs/image.pb.h>
 #include <gz/msgs/annotated_axis_aligned_2d_box.pb.h>
+#include <gz/msgs/annotated_axis_aligned_2d_box_v.pb.h>
 #include <gz/msgs/annotated_oriented_3d_box.pb.h>
+#include <gz/msgs/annotated_oriented_3d_box_v.pb.h>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Image.hh>

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -17,6 +17,7 @@
 
 #include <mutex>
 
+#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/image.pb.h>
 #include <gz/msgs/annotated_axis_aligned_2d_box.pb.h>
 #include <gz/msgs/annotated_axis_aligned_2d_box_v.pb.h>

--- a/test/integration/air_pressure.cc
+++ b/test/integration/air_pressure.cc
@@ -19,6 +19,8 @@
 
 #include <sdf/sdf.hh>
 
+#include <gz/msgs/fluid_pressure.pb.h>
+
 #include <gz/math/Helpers.hh>
 #include <gz/sensors/AirPressureSensor.hh>
 #include <gz/sensors/SensorFactory.hh>

--- a/test/integration/air_speed.cc
+++ b/test/integration/air_speed.cc
@@ -20,6 +20,9 @@
 #include <sdf/sdf.hh>
 
 #include <gz/math/Helpers.hh>
+
+#include <gz/msgs/air_speed.pb.h>
+
 #include <gz/sensors/AirSpeedSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/altimeter.cc
+++ b/test/integration/altimeter.cc
@@ -20,6 +20,9 @@
 #include <sdf/sdf.hh>
 
 #include <gz/math/Helpers.hh>
+
+#include <gz/msgs/altimeter.pb.h>
+
 #include <gz/sensors/AltimeterSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/boundingbox_camera.cc
+++ b/test/integration/boundingbox_camera.cc
@@ -18,7 +18,9 @@
 #include <gtest/gtest.h>
 
 #include <gz/msgs/annotated_axis_aligned_2d_box.pb.h>
+#include <gz/msgs/annotated_axis_aligned_2d_box_v.pb.h>
 #include <gz/msgs/annotated_oriented_3d_box.pb.h>
+#include <gz/msgs/annotated_oriented_3d_box_v.pb.h>
 
 #include <gz/common/Filesystem.hh>
 #include <gz/sensors/Manager.hh>

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
+#include <gz/msgs/camera_info.pb.h>
 #include <gz/msgs/image.pb.h>
 
 #include <gz/common/Console.hh>

--- a/test/integration/dvl.cc
+++ b/test/integration/dvl.cc
@@ -23,6 +23,8 @@
 #include <gz/math/Quaternion.hh>
 #include <gz/math/Vector3.hh>
 
+#include <gz/msgs/dvl_velocity_tracking.pb.h>
+
 #include <gz/rendering/Material.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>

--- a/test/integration/force_torque.cc
+++ b/test/integration/force_torque.cc
@@ -21,6 +21,8 @@
 
 #include <gz/math/Helpers.hh>
 
+#include <gz/msgs/wrench.pb.h>
+
 #include <gz/sensors/ForceTorqueSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/imu.cc
+++ b/test/integration/imu.cc
@@ -19,6 +19,8 @@
 
 #include <sdf/sdf.hh>
 
+#include <gz/msgs/imu.pb.h>
+
 #include <gz/sensors/ImuSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/magnetometer.cc
+++ b/test/integration/magnetometer.cc
@@ -19,6 +19,8 @@
 
 #include <sdf/sdf.hh>
 
+#include <gz/msgs/magnetometer.pb.h>
+
 #include <gz/sensors/MagnetometerSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/navsat.cc
+++ b/test/integration/navsat.cc
@@ -20,6 +20,9 @@
 #include <sdf/sdf.hh>
 
 #include <gz/math/Helpers.hh>
+
+#include <gz/msgs/navsat.pb.h>
+
 #include <gz/sensors/NavSatSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/segmentation_camera.cc
+++ b/test/integration/segmentation_camera.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <gz/msgs/image.pb.h>
+#include <gz/msgs/camera_info.pb.h>
 
 #include <gz/common/Filesystem.hh>
 #include <gz/sensors/Manager.hh>

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -18,6 +18,8 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
+#include <gz/msgs/annotated_oriented_3d_box_v.pb.h>
+#include <gz/msgs/annotated_axis_aligned_2d_box_v.pb.h>
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/image.pb.h>
 

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
+#include <gz/msgs/camera_info.pb.h>
 #include <gz/msgs/image.pb.h>
 
 #include <gz/common/Console.hh>


### PR DESCRIPTION
Many sensor tests didn't actually include the headers that they were using.  This breaks with the new message generation (we are probably transitively including less).