### PR TITLE
GaussianNoiseModel: avoid calling DblNormal with invalid standard deviation

### DIFF
--- a/src/GaussianNoiseModel.cc
+++ b/src/GaussianNoiseModel.cc
@@ -87,7 +87,10 @@ void GaussianNoiseModel::Load(const sdf::Noise &_sdf)
   double biasStdDev = 0;
   biasMean = _sdf.BiasMean();
   biasStdDev = _sdf.BiasStdDev();
-  this->dataPtr->bias = math::Rand::DblNormal(biasMean, biasStdDev);
+  if (biasStdDev > 0.0)
+    this->dataPtr->bias = math::Rand::DblNormal(biasMean, biasStdDev);
+  else
+    this->dataPtr->bias = biasMean;
 
   // With equal probability, we pick a negative bias (by convention,
   // rateBiasMean should be positive, though it would work fine if
@@ -108,8 +111,9 @@ void GaussianNoiseModel::Load(const sdf::Noise &_sdf)
 double GaussianNoiseModel::ApplyImpl(double _in, double _dt)
 {
   // Generate independent (uncorrelated) Gaussian noise to each input value.
-  double whiteNoise = math::Rand::DblNormal(
-      this->dataPtr->mean, this->dataPtr->stdDev);
+  double whiteNoise = this->dataPtr->stdDev > 0.0 ?
+      math::Rand::DblNormal(this->dataPtr->mean, this->dataPtr->stdDev) :
+      this->dataPtr->mean;
 
   // Generate varying (correlated) bias to each input value.
   // This implementation is based on the one available in Rotors:


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #395 

## Summary
The fix checks for zero standard deviation before sampling the normal distribution. If the standard deviation is zero, the mean is set directly. I've fixed both cases as mentioned in #395, as I think a crash is undesirable for both cases, but perhaps a warning should be emitted in Load() if the state standard deviation is zero.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.