### PR TITLE
Use GZ_ visibilty macro instead of custom _EXPORTS_API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,8 @@ find_package(Eigen3 REQUIRED)
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS)
+gz_configure_build(QUIT_IF_BUILD_ERRORS
+  HIDE_SYMBOLS_BY_DEFAULT)
 
 #============================================================================
 # Create package information

--- a/src/PointCloudUtil.hh
+++ b/src/PointCloudUtil.hh
@@ -32,16 +32,6 @@
 #include "gz/sensors/config.hh"
 #include "gz/sensors/Export.hh"
 
-#ifndef _WIN32
-#  define PointCloudUtil_EXPORTS_API
-#else
-#  if (defined(DepthPoints_EXPORTS))
-#    define PointCloudUtil_EXPORTS_API __declspec(dllexport)
-#  else
-#    define PointCloudUtil_EXPORTS_API __declspec(dllimport)
-#  endif
-#endif
-
 namespace gz
 {
   namespace sensors
@@ -52,7 +42,7 @@ namespace gz
     /// \brief Helper class that fills a msgs::PointCloudPacked message using
     /// image and depth data. The RgbdCameraSensor and DepthCameraSensor
     /// class use this.
-    class PointCloudUtil_EXPORTS_API PointCloudUtil
+    class GZ_SENSORS_VISIBLE PointCloudUtil
     {
       /// \brief Fill a msgs::PointCloudPacked.
       /// \param[in,out] _msg Point cloud message to fill. This message


### PR DESCRIPTION
Part of the works to enable visibility hidden by default https://github.com/gazebosim/gz-cmake/pull/392. Part of https://github.com/gazebosim/gz-cmake/issues/166

The PR replaces a custom visibility method by the macro provided by gz-cmake.