### PR TITLE
Airflow/Wind sensor

### DIFF
--- a/include/gz/sensors/AirFlowSensor.hh
+++ b/include/gz/sensors/AirFlowSensor.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef GZ_SENSORS_AIRSPEEDSENSOR_HH_
-#define GZ_SENSORS_AIRSPEEDSENSOR_HH_
+#ifndef GZ_SENSORS_AirFlowSensor_HH_
+#define GZ_SENSORS_AirFlowSensor_HH_
 
 #include <memory>
 
@@ -24,7 +24,7 @@
 #include <gz/utils/SuppressWarning.hh>
 
 #include <gz/sensors/config.hh>
-#include <gz/sensors/air_speed/Export.hh>
+#include <gz/sensors/air_flow/Export.hh>
 
 #include "gz/sensors/Sensor.hh"
 
@@ -36,19 +36,19 @@ namespace gz
     inline namespace GZ_SENSORS_VERSION_NAMESPACE {
     //
     /// \brief forward declarations
-    class AirSpeedSensorPrivate;
+    class AirFlowSensorPrivate;
 
-    /// \brief AirSpeed Sensor Class
+    /// \brief AirFlow Sensor Class
     ///
     /// A sensor that reports air speed through differential pressure readings.
-    class GZ_SENSORS_AIR_SPEED_VISIBLE AirSpeedSensor :
+    class GZ_SENSORS_air_flow_VISIBLE AirFlowSensor :
       public Sensor
     {
       /// \brief constructor
-      public: AirSpeedSensor();
+      public: AirFlowSensor();
 
       /// \brief destructor
-      public: virtual ~AirSpeedSensor();
+      public: virtual ~AirFlowSensor();
 
       /// \brief Load the sensor based on data from an sdf::Sensor object.
       /// \param[in] _sdf SDF Sensor parameters.
@@ -86,7 +86,7 @@ namespace gz
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal
-      private: std::unique_ptr<AirSpeedSensorPrivate> dataPtr;
+      private: std::unique_ptr<AirFlowSensorPrivate> dataPtr;
       GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }

--- a/include/gz/sensors/AirFlowSensor.hh
+++ b/include/gz/sensors/AirFlowSensor.hh
@@ -71,6 +71,9 @@ namespace gz
       /// \brief Update the velocity of the sensor
       public: void SetVelocity(const gz::math::Vector3d &_vel);
 
+      /// \brief Update the wind velocity in which the sensor is
+      public: void SetWindVelocity(const gz::math::Vector3d &_vel);
+
       using Sensor::Update;
 
       /// \brief Update the sensor and generate data

--- a/include/gz/sensors/AirFlowSensor.hh
+++ b/include/gz/sensors/AirFlowSensor.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef GZ_SENSORS_AirFlowSensor_HH_
-#define GZ_SENSORS_AirFlowSensor_HH_
+#ifndef GZ_SENSORS_AIRFLOWSENSOR_HH_
+#define GZ_SENSORS_AIRFLOWSENSOR_HH_
 
 #include <memory>
 
@@ -41,7 +41,7 @@ namespace gz
     /// \brief AirFlow Sensor Class
     ///
     /// A sensor that reports air speed through differential pressure readings.
-    class GZ_SENSORS_air_flow_VISIBLE AirFlowSensor :
+    class GZ_SENSORS_AIR_FLOW_VISIBLE AirFlowSensor :
       public Sensor
     {
       /// \brief constructor

--- a/include/gz/sensors/AirFlowSensor.hh
+++ b/include/gz/sensors/AirFlowSensor.hh
@@ -69,9 +69,11 @@ namespace gz
       public: gz::math::Vector3d Velocity() const;
 
       /// \brief Update the velocity of the sensor
+      /// \param[in] _vel The velocity of the sensor [m/s]
       public: void SetVelocity(const gz::math::Vector3d &_vel);
 
-      /// \brief Update the wind velocity in which the sensor is
+      /// \brief Update the wind velocity
+      /// \param[in] _vel The wind velocity [m/s]
       public: void SetWindVelocity(const gz::math::Vector3d &_vel);
 
       using Sensor::Update;

--- a/include/gz/sensors/AirFlowSensor.hh
+++ b/include/gz/sensors/AirFlowSensor.hh
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_SENSORS_AIRSPEEDSENSOR_HH_
+#define GZ_SENSORS_AIRSPEEDSENSOR_HH_
+
+#include <memory>
+
+#include <sdf/sdf.hh>
+
+#include <gz/utils/SuppressWarning.hh>
+
+#include <gz/sensors/config.hh>
+#include <gz/sensors/air_speed/Export.hh>
+
+#include "gz/sensors/Sensor.hh"
+
+namespace gz
+{
+  namespace sensors
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace GZ_SENSORS_VERSION_NAMESPACE {
+    //
+    /// \brief forward declarations
+    class AirSpeedSensorPrivate;
+
+    /// \brief AirSpeed Sensor Class
+    ///
+    /// A sensor that reports air speed through differential pressure readings.
+    class GZ_SENSORS_AIR_SPEED_VISIBLE AirSpeedSensor :
+      public Sensor
+    {
+      /// \brief constructor
+      public: AirSpeedSensor();
+
+      /// \brief destructor
+      public: virtual ~AirSpeedSensor();
+
+      /// \brief Load the sensor based on data from an sdf::Sensor object.
+      /// \param[in] _sdf SDF Sensor parameters.
+      /// \return true if loading was successful
+      public: virtual bool Load(const sdf::Sensor &_sdf) override;
+
+      /// \brief Load the sensor with SDF parameters.
+      /// \param[in] _sdf SDF Sensor parameters.
+      /// \return true if loading was successful
+      public: virtual bool Load(sdf::ElementPtr _sdf) override;
+
+      /// \brief Initialize values in the sensor
+      /// \return True on success
+      public: virtual bool Init() override;
+
+      /// \brief Get the current velocity.
+      /// \return Current velocity of the sensor.
+      public: gz::math::Vector3d Velocity() const;
+
+      /// \brief Update the velocity of the sensor
+      public: void SetVelocity(const gz::math::Vector3d &_vel);
+
+      using Sensor::Update;
+
+      /// \brief Update the sensor and generate data
+      /// \param[in] _now The current time
+      /// \return true if the update was successfull
+      public: virtual bool Update(
+        const std::chrono::steady_clock::duration &_now) override;
+
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const override;
+
+      GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
+      /// \brief Data pointer for private data
+      /// \internal
+      private: std::unique_ptr<AirSpeedSensorPrivate> dataPtr;
+      GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+    };
+    }
+  }
+}
+
+#endif

--- a/include/gz/sensors/SensorTypes.hh
+++ b/include/gz/sensors/SensorTypes.hh
@@ -209,6 +209,14 @@ namespace gz
       /// \sa AirSpeedSensor
       AIR_SPEED_NOISE_PASCALS = 25,
 
+      /// \brief Air flow noise streams for the air flow sensor
+      /// \sa AirFlowSensor
+      AIR_FLOW_SPEED_NOISE = 26,
+
+      /// \brief Air flow noise streams for the air flow sensor
+      /// \sa AirFlowSensor
+      AIR_FLOW_DIR_NOISE = 27,
+
       /// \internal
       /// \brief Indicator used to create an iterator over the enum. Do not
       /// use this.

--- a/src/AirFlowSensor.cc
+++ b/src/AirFlowSensor.cc
@@ -62,6 +62,9 @@ class gz::sensors::AirFlowSensorPrivate
   /// \brief Velocity of the air coming from the sensor
   public: gz::math::Vector3d vel;
 
+  /// \brief Velocity of the wind
+  public: gz::math::Vector3d wind_vel;
+
   /// \brief Noise added to speed measurement
   public: std::map<SensorNoiseType, NoisePtr> speed_noises;
   
@@ -164,7 +167,7 @@ bool AirFlowSensor::Update(
   frame->set_key("frame_id");
   frame->add_value(this->FrameId());
 
-  math::Vector3d wind_vel_{0, 0, 0};
+  math::Vector3d wind_vel_ = this-dataPtr->wind_vel;
   math::Quaterniond veh_q_world_to_body = this->Pose().Rot();
 
   // calculate differential pressure + noise in hPa
@@ -224,6 +227,11 @@ gz::math::Vector3d AirFlowSensor::Velocity() const
 void AirFlowSensor::SetVelocity(const gz::math::Vector3d &_vel)
 {
   this->dataPtr->vel = _vel;
+}
+
+void AirFlowSensor::SetWindVelocity(const gz::math::Vector3d &_vel)
+{
+  this->dataPtr->wind_vel = _vel;
 }
 
 //////////////////////////////////////////////////

--- a/src/AirFlowSensor.cc
+++ b/src/AirFlowSensor.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#if defined(_MSC_VER)
+  #pragma warning(push)
+  #pragma warning(disable: 4005)
+  #pragma warning(disable: 4251)
+#endif
+#include <gz/msgs/air_speed_sensor.pb.h>
+#if defined(_MSC_VER)
+  #pragma warning(pop)
+#endif
+#include <gz/msgs/Utility.hh>
+
+#include <gz/common/Profiler.hh>
+#include <gz/transport/Node.hh>
+
+#include "gz/sensors/GaussianNoiseModel.hh"
+#include "gz/sensors/Noise.hh"
+#include "gz/sensors/SensorTypes.hh"
+#include "gz/sensors/SensorFactory.hh"
+#include "gz/sensors/AirSpeedSensor.hh"
+
+using namespace gz;
+using namespace sensors;
+
+// altitude AMSL see level [m]
+static constexpr auto kDefaultHomeAltAmsl = 0.0f;
+// international standard atmosphere (troposphere model - valid up to 11km).
+// temperature at MSL [K] (15 [C])
+static constexpr auto kTemperaturMsl = 288.15f;
+// pressure at MSL [Pa]
+static constexpr auto kPressureMsl = 101325.0f;
+// reduction in temperature with altitude for troposphere [K/m]
+static constexpr auto kLapseRate = 0.0065f;
+// air density at MSL [kg/m^3]
+static constexpr auto kAirDensityMsl = 1.225f;
+
+/// \brief Private data for AirSpeedSensor
+class gz::sensors::AirSpeedSensorPrivate
+{
+  /// \brief node to create publisher
+  public: transport::Node node;
+
+  /// \brief publisher to publish air speed messages.
+  public: transport::Node::Publisher pub;
+
+  /// \brief true if Load() has been called and was successful
+  public: bool initialized = false;
+
+  /// \brief Pressure in pascals.
+  public: double pressure = 0.0;
+
+  /// \brief Velocity of the air coming from the sensor
+  public: gz::math::Vector3d vel;
+
+  /// \brief Noise added to sensor data
+  public: std::map<SensorNoiseType, NoisePtr> noises;
+};
+
+//////////////////////////////////////////////////
+AirSpeedSensor::AirSpeedSensor()
+  : dataPtr(new AirSpeedSensorPrivate())
+{
+}
+
+//////////////////////////////////////////////////
+AirSpeedSensor::~AirSpeedSensor()
+{
+}
+
+//////////////////////////////////////////////////
+bool AirSpeedSensor::Init()
+{
+  return this->Sensor::Init();
+}
+
+//////////////////////////////////////////////////
+bool AirSpeedSensor::Load(const sdf::Sensor &_sdf)
+{
+  if (!Sensor::Load(_sdf))
+    return false;
+
+  if (_sdf.Type() != sdf::SensorType::AIR_SPEED)
+  {
+    gzerr << "Attempting to a load an AirSpeed sensor, but received "
+      << "a " << _sdf.TypeStr() << std::endl;
+    return false;
+  }
+
+  if (_sdf.AirSpeedSensor() == nullptr)
+  {
+    gzerr << "Attempting to a load an AirSpeed sensor, but received "
+      << "a null sensor." << std::endl;
+    return false;
+  }
+
+  if (this->Topic().empty())
+    this->SetTopic("/air_speed");
+
+  this->dataPtr->pub =
+      this->dataPtr->node.Advertise<msgs::AirSpeedSensor>(
+      this->Topic());
+
+  if (!this->dataPtr->pub)
+  {
+    gzerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
+    return false;
+  }
+
+  gzdbg << "Air speed for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
+  // Load the noise parameters
+  if (_sdf.AirSpeedSensor()->PressureNoise().Type() != sdf::NoiseType::NONE)
+  {
+    this->dataPtr->noises[AIR_SPEED_NOISE_PASCALS] =
+      NoiseFactory::NewNoiseModel(_sdf.AirSpeedSensor()->PressureNoise());
+  }
+
+  this->dataPtr->initialized = true;
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool AirSpeedSensor::Load(sdf::ElementPtr _sdf)
+{
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(_sdf);
+  return this->Load(sdfSensor);
+}
+
+//////////////////////////////////////////////////
+bool AirSpeedSensor::Update(
+  const std::chrono::steady_clock::duration &_now)
+{
+  GZ_PROFILE("AirSpeedSensor::Update");
+  if (!this->dataPtr->initialized)
+  {
+    gzerr << "Not initialized, update ignored.\n";
+    return false;
+  }
+
+  msgs::AirSpeedSensor msg;
+  *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
+  auto frame = msg.mutable_header()->add_data();
+  frame->set_key("frame_id");
+  frame->add_value(this->FrameId());
+
+  // compute the air density at the local altitude / temperature
+  // Z-component from ENU
+  const float alt_rel = static_cast<float>(this->Pose().Pos().Z());
+  const float alt_amsl = kDefaultHomeAltAmsl + alt_rel;
+  const float temperature_local = kTemperaturMsl - kLapseRate * alt_amsl;
+  const float density_ratio = powf(kTemperaturMsl / temperature_local , 4.256f);
+  const float air_density = kAirDensityMsl / density_ratio;
+
+  math::Vector3d wind_vel_{0, 0, 0};
+  math::Quaterniond veh_q_world_to_body = this->Pose().Rot();
+
+  // calculate differential pressure + noise in hPa
+  math::Vector3d air_vel_in_body_ = this->dataPtr->vel -
+    veh_q_world_to_body.RotateVectorReverse(wind_vel_);
+  float diff_pressure = math::sgn(air_vel_in_body_.X()) * 0.005f * air_density
+    * air_vel_in_body_.X() * air_vel_in_body_.X();
+
+  // Apply pressure noise
+  if (this->dataPtr->noises.find(AIR_SPEED_NOISE_PASCALS) !=
+      this->dataPtr->noises.end())
+  {
+    diff_pressure =
+      this->dataPtr->noises[AIR_SPEED_NOISE_PASCALS]->Apply(
+          diff_pressure);
+    msg.mutable_pressure_noise()->set_type(msgs::SensorNoise::GAUSSIAN);
+  }
+
+  msg.set_diff_pressure(diff_pressure * 100.0f);
+  msg.set_temperature(temperature_local);
+
+  // publish
+  this->AddSequence(msg.mutable_header());
+  this->dataPtr->pub.Publish(msg);
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+gz::math::Vector3d AirSpeedSensor::Velocity() const
+{
+  return this->dataPtr->vel;
+}
+
+//////////////////////////////////////////////////
+void AirSpeedSensor::SetVelocity(const gz::math::Vector3d &_vel)
+{
+  this->dataPtr->vel = _vel;
+}
+
+//////////////////////////////////////////////////
+bool AirSpeedSensor::HasConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}

--- a/src/AirFlowSensor.cc
+++ b/src/AirFlowSensor.cc
@@ -20,7 +20,7 @@
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
 #endif
-#include <gz/msgs/air_speed_sensor.pb.h>
+#include <gz/msgs/air_flow_sensor.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif
@@ -33,7 +33,7 @@
 #include "gz/sensors/Noise.hh"
 #include "gz/sensors/SensorTypes.hh"
 #include "gz/sensors/SensorFactory.hh"
-#include "gz/sensors/AirSpeedSensor.hh"
+#include "gz/sensors/AirFlowSensor.hh"
 
 using namespace gz;
 using namespace sensors;
@@ -50,8 +50,8 @@ static constexpr auto kLapseRate = 0.0065f;
 // air density at MSL [kg/m^3]
 static constexpr auto kAirDensityMsl = 1.225f;
 
-/// \brief Private data for AirSpeedSensor
-class gz::sensors::AirSpeedSensorPrivate
+/// \brief Private data for AirFlowSensor
+class gz::sensors::AirFlowSensorPrivate
 {
   /// \brief node to create publisher
   public: transport::Node node;
@@ -73,47 +73,47 @@ class gz::sensors::AirSpeedSensorPrivate
 };
 
 //////////////////////////////////////////////////
-AirSpeedSensor::AirSpeedSensor()
-  : dataPtr(new AirSpeedSensorPrivate())
+AirFlowSensor::AirFlowSensor()
+  : dataPtr(new AirFlowSensorPrivate())
 {
 }
 
 //////////////////////////////////////////////////
-AirSpeedSensor::~AirSpeedSensor()
+AirFlowSensor::~AirFlowSensor()
 {
 }
 
 //////////////////////////////////////////////////
-bool AirSpeedSensor::Init()
+bool AirFlowSensor::Init()
 {
   return this->Sensor::Init();
 }
 
 //////////////////////////////////////////////////
-bool AirSpeedSensor::Load(const sdf::Sensor &_sdf)
+bool AirFlowSensor::Load(const sdf::Sensor &_sdf)
 {
   if (!Sensor::Load(_sdf))
     return false;
 
-  if (_sdf.Type() != sdf::SensorType::AIR_SPEED)
+  if (_sdf.Type() != sdf::SensorType::air_flow)
   {
-    gzerr << "Attempting to a load an AirSpeed sensor, but received "
+    gzerr << "Attempting to a load an AirFlow sensor, but received "
       << "a " << _sdf.TypeStr() << std::endl;
     return false;
   }
 
-  if (_sdf.AirSpeedSensor() == nullptr)
+  if (_sdf.AirFlowSensor() == nullptr)
   {
-    gzerr << "Attempting to a load an AirSpeed sensor, but received "
+    gzerr << "Attempting to a load an AirFlow sensor, but received "
       << "a null sensor." << std::endl;
     return false;
   }
 
   if (this->Topic().empty())
-    this->SetTopic("/air_speed");
+    this->SetTopic("/air_flow");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<msgs::AirSpeedSensor>(
+      this->dataPtr->node.Advertise<msgs::AirFlowSensor>(
       this->Topic());
 
   if (!this->dataPtr->pub)
@@ -126,10 +126,10 @@ bool AirSpeedSensor::Load(const sdf::Sensor &_sdf)
          << this->Topic() << "]" << std::endl;
 
   // Load the noise parameters
-  if (_sdf.AirSpeedSensor()->PressureNoise().Type() != sdf::NoiseType::NONE)
+  if (_sdf.AirFlowSensor()->PressureNoise().Type() != sdf::NoiseType::NONE)
   {
-    this->dataPtr->noises[AIR_SPEED_NOISE_PASCALS] =
-      NoiseFactory::NewNoiseModel(_sdf.AirSpeedSensor()->PressureNoise());
+    this->dataPtr->noises[air_flow_NOISE_PASCALS] =
+      NoiseFactory::NewNoiseModel(_sdf.AirFlowSensor()->PressureNoise());
   }
 
   this->dataPtr->initialized = true;
@@ -137,7 +137,7 @@ bool AirSpeedSensor::Load(const sdf::Sensor &_sdf)
 }
 
 //////////////////////////////////////////////////
-bool AirSpeedSensor::Load(sdf::ElementPtr _sdf)
+bool AirFlowSensor::Load(sdf::ElementPtr _sdf)
 {
   sdf::Sensor sdfSensor;
   sdfSensor.Load(_sdf);
@@ -145,17 +145,17 @@ bool AirSpeedSensor::Load(sdf::ElementPtr _sdf)
 }
 
 //////////////////////////////////////////////////
-bool AirSpeedSensor::Update(
+bool AirFlowSensor::Update(
   const std::chrono::steady_clock::duration &_now)
 {
-  GZ_PROFILE("AirSpeedSensor::Update");
+  GZ_PROFILE("AirFlowSensor::Update");
   if (!this->dataPtr->initialized)
   {
     gzerr << "Not initialized, update ignored.\n";
     return false;
   }
 
-  msgs::AirSpeedSensor msg;
+  msgs::AirFlowSensor msg;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
@@ -179,11 +179,11 @@ bool AirSpeedSensor::Update(
     * air_vel_in_body_.X() * air_vel_in_body_.X();
 
   // Apply pressure noise
-  if (this->dataPtr->noises.find(AIR_SPEED_NOISE_PASCALS) !=
+  if (this->dataPtr->noises.find(air_flow_NOISE_PASCALS) !=
       this->dataPtr->noises.end())
   {
     diff_pressure =
-      this->dataPtr->noises[AIR_SPEED_NOISE_PASCALS]->Apply(
+      this->dataPtr->noises[air_flow_NOISE_PASCALS]->Apply(
           diff_pressure);
     msg.mutable_pressure_noise()->set_type(msgs::SensorNoise::GAUSSIAN);
   }
@@ -199,19 +199,19 @@ bool AirSpeedSensor::Update(
 }
 
 //////////////////////////////////////////////////
-gz::math::Vector3d AirSpeedSensor::Velocity() const
+gz::math::Vector3d AirFlowSensor::Velocity() const
 {
   return this->dataPtr->vel;
 }
 
 //////////////////////////////////////////////////
-void AirSpeedSensor::SetVelocity(const gz::math::Vector3d &_vel)
+void AirFlowSensor::SetVelocity(const gz::math::Vector3d &_vel)
 {
   this->dataPtr->vel = _vel;
 }
 
 //////////////////////////////////////////////////
-bool AirSpeedSensor::HasConnections() const
+bool AirFlowSensor::HasConnections() const
 {
   return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
 }

--- a/src/AirFlowSensor.cc
+++ b/src/AirFlowSensor.cc
@@ -50,16 +50,7 @@ class gz::sensors::AirFlowSensorPrivate
   /// \brief true if Load() has been called and was successful
   public: bool initialized = false;
 
-  /// \brief Pressure in pascals.
-  public: double pressure = 0.0;
-
-  /// \brief Resolution of: [deg]
-  public: double direction_resolution = 0.0;
-
-  /// \brief Pressure in pascals.
-  public: double speed_resolution = 0.0;
-
-  /// \brief Velocity of the air coming from the sensor
+  /// \brief Velocity of the sensor
   public: gz::math::Vector3d vel;
 
   /// \brief Velocity of the wind
@@ -67,7 +58,7 @@ class gz::sensors::AirFlowSensorPrivate
 
   /// \brief Noise added to speed measurement
   public: std::map<SensorNoiseType, NoisePtr> speed_noises;
-  
+
   /// \brief Noise added to directional measurement
   public: std::map<SensorNoiseType, NoisePtr> dir_noises;
 };

--- a/src/AirFlowSensor.cc
+++ b/src/AirFlowSensor.cc
@@ -95,7 +95,7 @@ bool AirFlowSensor::Load(const sdf::Sensor &_sdf)
   if (!Sensor::Load(_sdf))
     return false;
 
-  if (_sdf.Type() != sdf::SensorType::air_flow)
+  if (_sdf.Type() != sdf::SensorType::AIR_FLOW)
   {
     gzerr << "Attempting to a load an AirFlow sensor, but received "
       << "a " << _sdf.TypeStr() << std::endl;
@@ -128,13 +128,13 @@ bool AirFlowSensor::Load(const sdf::Sensor &_sdf)
   // Load the noise parameters
   if (_sdf.AirFlowSensor()->SpeedNoise().Type() != sdf::NoiseType::NONE)
   {
-    this->dataPtr->speed_noises[AIR_FLOW_SPEED_NOISE_PASCALS] =
+    this->dataPtr->speed_noises[AIR_FLOW_SPEED_NOISE] =
       NoiseFactory::NewNoiseModel(_sdf.AirFlowSensor()->SpeedNoise());
   }
 
   if (_sdf.AirFlowSensor()->DirectionNoise().Type() != sdf::NoiseType::NONE)
   {
-    this->dataPtr->dir_noises[AIR_FLOW_DIR_NOISE_PASCALS] =
+    this->dataPtr->dir_noises[AIR_FLOW_DIR_NOISE] =
       NoiseFactory::NewNoiseModel(_sdf.AirFlowSensor()->DirectionNoise());
   }
 
@@ -167,7 +167,7 @@ bool AirFlowSensor::Update(
   frame->set_key("frame_id");
   frame->add_value(this->FrameId());
 
-  math::Vector3d wind_vel_ = this-dataPtr->wind_vel;
+  math::Vector3d wind_vel_ = this->dataPtr->wind_vel;
   math::Quaterniond veh_q_world_to_body = this->Pose().Rot();
 
   // calculate differential pressure + noise in hPa
@@ -178,11 +178,11 @@ bool AirFlowSensor::Update(
                                               air_vel_in_body_.X());
 
   // Apply noise
-  if (this->dataPtr->dir_noises.find(air_flow_dir_NOISE_PASCALS) !=
+  if (this->dataPtr->dir_noises.find(AIR_FLOW_DIR_NOISE) !=
       this->dataPtr->dir_noises.end())
   {
     airflow_direction_in_xy_plane =
-      this->dataPtr->dir_noises[air_flow_dir_NOISE_PASCALS]->Apply(
+      this->dataPtr->dir_noises[AIR_FLOW_DIR_NOISE]->Apply(
           airflow_direction_in_xy_plane);
     msg.mutable_direction_noise()->set_type(msgs::SensorNoise::GAUSSIAN);
   }
@@ -191,14 +191,14 @@ bool AirFlowSensor::Update(
 
 
   air_vel_in_body_.Z() = 0;
-  double airflow_speed =  air_vel_in_body.Length();
+  double airflow_speed =  air_vel_in_body_.Length();
 
   // Apply noise
-  if (this->dataPtr->speed_noises.find(air_flow_speed_NOISE_PASCALS) !=
+  if (this->dataPtr->speed_noises.find(AIR_FLOW_SPEED_NOISE) !=
       this->dataPtr->speed_noises.end())
   {
     airflow_speed =
-      this->dataPtr->speed_noises[air_flow_speed_NOISE_PASCALS]->Apply(
+      this->dataPtr->speed_noises[AIR_FLOW_SPEED_NOISE]->Apply(
           airflow_direction_in_xy_plane);
     msg.mutable_speed_noise()->set_type(msgs::SensorNoise::GAUSSIAN);
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,9 @@ gz_add_component(imu SOURCES ${imu_sources} GET_TARGET_NAME imu_target)
 set(altimeter_sources AltimeterSensor.cc)
 gz_add_component(altimeter SOURCES ${altimeter_sources} GET_TARGET_NAME altimeter_target)
 
+set(air_flow_sources AirFlowSensor.cc)
+gz_add_component(air_flow SOURCES ${air_flow_sources} GET_TARGET_NAME air_flow_target)
+
 set(air_pressure_sources AirPressureSensor.cc)
 gz_add_component(air_pressure SOURCES ${air_pressure_sources} GET_TARGET_NAME air_pressure_target)
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -15,6 +15,7 @@ set(dri_tests
 )
 
 set(tests
+  air_flow.cc
   air_pressure.cc
   air_speed.cc
   altimeter.cc
@@ -58,6 +59,7 @@ gz_build_tests(TYPE INTEGRATION
   SOURCES
     ${tests}
   LIB_DEPS
+    ${PROJECT_LIBRARY_TARGET_NAME}-air_flow
     ${PROJECT_LIBRARY_TARGET_NAME}-air_pressure
     ${PROJECT_LIBRARY_TARGET_NAME}-air_speed
     ${PROJECT_LIBRARY_TARGET_NAME}-altimeter

--- a/test/integration/air_flow.cc
+++ b/test/integration/air_flow.cc
@@ -35,7 +35,7 @@ sdf::ElementPtr AirFlowToSdf(const std::string &_name,
   std::ostringstream stream;
   stream
     << "<?xml version='1.0'?>"
-    << "<sdf version='1.6'>"
+    << "<sdf version='1.10'>"
     << " <model name='m1'>"
     << "  <link name='link1'>"
     << "    <sensor name='" << _name << "' type='air_flow'>"
@@ -67,7 +67,7 @@ sdf::ElementPtr AirFlowToSdfWithNoise(const std::string &_name,
   std::ostringstream stream;
   stream
     << "<?xml version='1.0'?>"
-    << "<sdf version='1.6'>"
+    << "<sdf version='1.10'>"
     << " <model name='m1'>"
     << "  <link name='link1'>"
     << "    <sensor name='" << _name << "' type='air_flow'>"

--- a/test/integration/air_flow.cc
+++ b/test/integration/air_flow.cc
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <sdf/sdf.hh>
+
+#include <gz/math/Helpers.hh>
+#include <gz/sensors/AirFlowSensor.hh>
+#include <gz/sensors/SensorFactory.hh>
+
+#include "test_config.hh"  // NOLINT(build/include)
+#include "TransportTestTools.hh"
+
+/// \brief Helper function to create an air flow sdf element
+sdf::ElementPtr AirFlowToSdf(const std::string &_name,
+    const gz::math::Pose3d &_pose, const double _updateRate,
+    const std::string &_topic, const bool _alwaysOn,
+    const bool _visualize)
+{
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='" << _name << "' type='air_flow'>"
+    << "      <pose>" << _pose << "</pose>"
+    << "      <topic>" << _topic << "</topic>"
+    << "      <update_rate>"<< _updateRate <<"</update_rate>"
+    << "      <alwaysOn>" << _alwaysOn <<"</alwaysOn>"
+    << "      <visualize>" << _visualize << "</visualize>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed))
+    return sdf::ElementPtr();
+
+  return sdfParsed->Root()->GetElement("model")->GetElement("link")
+    ->GetElement("sensor");
+}
+
+/// \brief Helper function to create an air flow sdf element with noise
+sdf::ElementPtr AirFlowToSdfWithNoise(const std::string &_name,
+    const gz::math::Pose3d &_pose, const double _updateRate,
+    const std::string &_topic, const bool _alwaysOn,
+    const bool _visualize, double _mean, double _stddev, double _bias)
+{
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='" << _name << "' type='air_flow'>"
+    << "      <pose>" << _pose << "</pose>"
+    << "      <topic>" << _topic << "</topic>"
+    << "      <update_rate>"<< _updateRate <<"</update_rate>"
+    << "      <alwaysOn>" << _alwaysOn <<"</alwaysOn>"
+    << "      <visualize>" << _visualize << "</visualize>"
+    << "      <air_flow>"
+    << "        <speed>"
+    << "          <noise type='gaussian'>"
+    << "            <mean>" << _mean << "</mean>"
+    << "            <stddev>" << _stddev << "</stddev>"
+    << "            <bias_mean>" << _bias << "</bias_mean>"
+    << "          </noise>"
+    << "        </speed>"
+    << "        <direction>"
+    << "          <noise type='gaussian'>"
+    << "            <mean>" << _mean << "</mean>"
+    << "            <stddev>" << _stddev << "</stddev>"
+    << "            <bias_mean>" << _bias << "</bias_mean>"
+    << "          </noise>"
+    << "        </direction>"
+    << "      </air_flow>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed))
+    return sdf::ElementPtr();
+
+  return sdfParsed->Root()->GetElement("model")->GetElement("link")
+    ->GetElement("sensor");
+}
+
+/// \brief Test air flow sensor
+class AirFlowSensorTest: public testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    gz::common::Console::SetVerbosity(4);
+  }
+};
+
+/////////////////////////////////////////////////
+TEST_F(AirFlowSensorTest, CreateAirFlow)
+{
+  // Create SDF describing an air_pressure sensor
+  const std::string name = "TestAirFlow";
+  const std::string topic = "/gz/sensors/test/air_flow";
+  const std::string topicNoise = "/gz/sensors/test/air_flow_noise";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+
+  // Create sensor SDF
+  gz::math::Pose3d sensorPose(gz::math::Vector3d(0.25, 0.0, 0.5),
+      gz::math::Quaterniond::Identity);
+  sdf::ElementPtr AirFlowSdf = AirFlowToSdf(name, sensorPose,
+        updateRate, topic, alwaysOn, visualize);
+
+  sdf::ElementPtr AirFlowSdfNoise = AirFlowToSdfWithNoise(name,
+      sensorPose, updateRate, topicNoise, alwaysOn, visualize, 1.0, 0.2, 10.0);
+
+  // create the sensor using sensor factory
+  gz::sensors::SensorFactory sf;
+  std::unique_ptr<gz::sensors::AirFlowSensor> sensor =
+      sf.CreateSensor<gz::sensors::AirFlowSensor>(AirFlowSdf);
+  ASSERT_NE(nullptr, sensor);
+
+  EXPECT_EQ(name, sensor->Name());
+  EXPECT_EQ(topic, sensor->Topic());
+  EXPECT_DOUBLE_EQ(updateRate, sensor->UpdateRate());
+
+  std::unique_ptr<gz::sensors::AirFlowSensor> sensorNoise =
+      sf.CreateSensor<gz::sensors::AirFlowSensor>(
+          AirFlowSdfNoise);
+  ASSERT_NE(nullptr, sensorNoise);
+
+  EXPECT_EQ(name, sensorNoise->Name());
+  EXPECT_EQ(topicNoise, sensorNoise->Topic());
+  EXPECT_DOUBLE_EQ(updateRate, sensorNoise->UpdateRate());
+}
+
+/////////////////////////////////////////////////
+TEST_F(AirFlowSensorTest, SensorReadings)
+{
+  // Create SDF describing an air_flow sensor
+  const std::string name = "TestAirFlow";
+  const std::string topic = "/gz/sensors/test/air_flow";
+  const std::string topicNoise = "/gz/sensors/test/air_flow_noise";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+
+  // Create sensor SDF
+  gz::math::Pose3d sensorPose(gz::math::Vector3d(0.25, 0.0, 0.5),
+      gz::math::Quaterniond::Identity);
+  sdf::ElementPtr AirFlowSdf = AirFlowToSdf(name, sensorPose,
+        updateRate, topic, alwaysOn, visualize);
+
+  sdf::ElementPtr AirFlowSdfNoise = AirFlowToSdfWithNoise(name,
+      sensorPose, updateRate, topicNoise, alwaysOn, visualize, 1.0, 0.2, 10.0);
+
+  // create the sensor using sensor factory
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::AirFlowSensor>(
+      AirFlowSdf);
+  ASSERT_NE(nullptr, sensor);
+  EXPECT_FALSE(sensor->HasConnections());
+
+  auto sensorNoise = sf.CreateSensor<gz::sensors::AirFlowSensor>(
+      AirFlowSdfNoise);
+  ASSERT_NE(nullptr, sensorNoise);
+
+  sensor->SetPose(
+      gz::math::Pose3d(0, 0, 1.5, 0, 0, 0) * sensorNoise->Pose());
+
+  // verify msg received on the topic
+  WaitForMessageTestHelper<gz::msgs::AirFlowSensor> msgHelper(topic);
+  EXPECT_TRUE(sensor->HasConnections());
+  sensor->Update(std::chrono::steady_clock::duration(std::chrono::seconds(1)));
+  EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
+  auto msg = msgHelper.Message();
+  EXPECT_EQ(1, msg.header().stamp().sec());
+  EXPECT_EQ(0, msg.header().stamp().nsec());
+  EXPECT_DOUBLE_EQ(0.0, msg.xy_speed());
+  EXPECT_DOUBLE_EQ(0.0, msg.xy_direction());
+
+  // verify msg with noise received on the topic
+  WaitForMessageTestHelper<gz::msgs::AirFlowSensor>
+    msgHelperNoise(topicNoise);
+  sensorNoise->Update(std::chrono::steady_clock::duration(
+      std::chrono::seconds(1)), false);
+  EXPECT_TRUE(msgHelperNoise.WaitForMessage()) << msgHelperNoise;
+  auto msgNoise = msgHelperNoise.Message();
+  EXPECT_EQ(1, msg.header().stamp().sec());
+  EXPECT_EQ(0, msg.header().stamp().nsec());
+  EXPECT_FALSE(gz::math::equal(0.0, msgNoise.xy_speed()));
+  EXPECT_FALSE(gz::math::equal(0.0, msgNoise.xy_direction()));
+}
+
+/////////////////////////////////////////////////
+TEST_F(AirFlowSensorTest, Topic)
+{
+  const std::string name = "TestAirFlow";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+  auto sensorPose = gz::math::Pose3d();
+
+  // Factory
+  gz::sensors::SensorFactory factory;
+
+  // Default topic
+  {
+    const std::string topic;
+    auto AirFlowSdf = AirFlowToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto AirFlow = factory.CreateSensor<
+        gz::sensors::AirFlowSensor>(AirFlowSdf);
+    ASSERT_NE(nullptr, AirFlow);
+
+    EXPECT_EQ("/air_flow", AirFlow->Topic());
+  }
+
+  // Convert to valid topic
+  {
+    const std::string topic = "/topic with spaces/@~characters//";
+    auto AirFlowSdf = AirFlowToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto AirFlow = factory.CreateSensor<
+        gz::sensors::AirFlowSensor>(AirFlowSdf);
+    ASSERT_NE(nullptr, AirFlow);
+
+    EXPECT_EQ("/topic_with_spaces/characters", AirFlow->Topic());
+  }
+
+  // Invalid topic
+  {
+    const std::string topic = "@@@";
+    auto AirFlowSdf = AirFlowToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor<
+        gz::sensors::AirFlowSensor>(AirFlowSdf);
+    ASSERT_EQ(nullptr, sensor);
+  }
+}


### PR DESCRIPTION
# 🎉 New feature
## Summary

This adds an airflow sensor. These sensors are generally used to measure wind and are ultrasonic devices, measuring the airflow speed and direction using the Doppler effect.

Depends on:

* https://github.com/gazebosim/sdformat/pull/1349
* https://github.com/gazebosim/gz-msgs/pull/411

Here is some use cases of such sensors from a manufacturer sensor which we have used.
https://fttechnologies.com/case-studies.

This is part of a larger plan to support an airflow sensor in PX4. @dagar

The code is heavily based on the Airspeed Sensor

##Test it

Test are added to ensure correct use.
Checklist

Signed all commits for DCO
Added tests
Added example and/or tutorial
Updated documentation (as needed)
Updated migration guide (as needed)
Consider updating Python bindings (if the library has them)
codecheck passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

    While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

Note to maintainers: Remember to use Squash-Merge and edit the commit message to match the pull request summary while retaining Signed-off-by messages.