### PR TITLE
Prepare for 3.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-sensors3 VERSION 3.5.0)
+project(ignition-sensors3 VERSION 3.6.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,30 @@
 ## Gazebo Sensors 3
 
+### Gazebo Sensors 3.6.0 (2024-01-05)
+
+1. Update github action workflows
+    * [Pull request #401](https://github.com/gazebosim/gz-sensors/pull/401)
+    * [Pull request #335](https://github.com/gazebosim/gz-sensors/pull/335)
+    * [Pull request #334](https://github.com/gazebosim/gz-sensors/pull/334)
+
+1. Clean up rendering resources
+    * [Pull request #324](https://github.com/gazebosim/gz-sensors/pull/324)
+
+1. Destroy rendering sensors when sensor is removed
+    * [Pull request #169](https://github.com/gazebosim/gz-sensors/pull/169)
+
+1. Support protobuf >= 22
+    * [Pull request #351](https://github.com/gazebosim/gz-sensors/pull/351)
+
+1. Fix links in Changelog
+    * [Pull request #330](https://github.com/gazebosim/gz-sensors/pull/330)
+
+1. Fix Camera info test
+    * [Pull request #326](https://github.com/gazebosim/gz-sensors/pull/326)
+
+1. Added Camera Info topic support for cameras
+    * [Pull request #285](https://github.com/gazebosim/gz-sensors/pull/285)
+
 ### Gazebo Sensors 3.5.0 (2022-11-30)
 
 1. Add missing DEPENDS_ON_COMPONENTS parameters.


### PR DESCRIPTION


<!-- For maintainers only -->

# 🎈 Release

Preparation for 3.6.0 release.

Comparison to <x.y.z>: https://github.com/gazebosim/gz-sensors/compare/ignition-sensors3_3.5.0...prep_3.6.0



## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
