### PR TITLE
Allow specifying gz_frame_id as an alternative to ignition_frame_id

### DIFF
--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -148,6 +148,18 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
     if (element->HasElement("ignition_frame_id"))
     {
       this->frame_id = element->Get<std::string>("ignition_frame_id");
+      // Warn if both ignition_frame_id and gz_frame_id are specified
+      if (element->HasElement("gz_frame_id"))
+      {
+        ignwarn << "Found both `ignition_frame_id` and `gz_frame_id` in sensor"
+                << this->name << ". Only `ignition_frame_id` will be used\n";
+      }
+    }
+    else if (element->HasElement("gz_frame_id"))
+    {
+      // Also read gz_frame_id to support SDF that's compatible with newer
+      // versions of Gazebo.
+      this->frame_id = element->Get<std::string>("gz_frame_id");
     }
     else
     {

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -350,6 +350,61 @@ TEST(Sensor_TEST, SetRateZeroService)
   EXPECT_FLOAT_EQ(20.0, sensor.UpdateRate());
 }
 
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, FrameIdFromSdf)
+{
+  auto loadSensorWithSdfParam =
+      [](TestSensor &_testSensor, const std::string &_sensorParam)
+  {
+    const std::string sensorSdf = R"(
+    <sdf version="1.9">
+      <model name="m1">
+        <link name="link1">
+          <sensor name="test" type="imu">)" +
+                                  _sensorParam + R"(
+          </sensor>
+        </link>
+      </model>
+    </sdf>
+    )";
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sensorSdf);
+    ASSERT_TRUE(errors.empty()) << errors;
+    auto *model = root.Model();
+    ASSERT_NE(model, nullptr);
+    auto *link = model->LinkByIndex(0);
+    ASSERT_NE(link, nullptr);
+    auto *sensor = link->SensorByIndex(0);
+    ASSERT_NE(sensor, nullptr);
+
+    _testSensor.Load(*sensor);
+  };
+
+  {
+    TestSensor testSensor;
+    loadSensorWithSdfParam(testSensor, "");
+    EXPECT_EQ("test", testSensor.FrameId());
+  }
+  {
+    TestSensor testSensor;
+    loadSensorWithSdfParam(
+        testSensor, "<ignition_frame_id>custom_frame_id</ignition_frame_id>");
+    EXPECT_EQ("custom_frame_id", testSensor.FrameId());
+  }
+  {
+    TestSensor testSensor;
+    loadSensorWithSdfParam(testSensor,
+                           "<gz_frame_id>custom_frame_id</gz_frame_id>");
+    EXPECT_EQ("custom_frame_id", testSensor.FrameId());
+  }
+  {
+    TestSensor testSensor;
+    loadSensorWithSdfParam(testSensor, R"(
+      <ignition_frame_id>custom_frame_id</ignition_frame_id>
+      <gz_frame_id>other_custom_frame_id</gz_frame_id>)");
+    EXPECT_EQ("custom_frame_id", testSensor.FrameId());
+  }
+}
 
 //////////////////////////////////////////////////
 int main(int argc, char **argv)


### PR DESCRIPTION
# 🎉 New feature

## Summary
This is meant to help migration to newer versions of Gazebo and allows users to replace ignition_frame_id in their SDF files while still in Fortress.

See https://github.com/ros-planning/navigation2/pull/3634#discussion_r1443279660 for more context

## Test it
`./UNIT_Sensor_TEST`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.