### PR TITLE
DepthCamera and RGBDCamera - optimize RGB point cloud connection

### DIFF
--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -407,12 +407,6 @@ bool DepthCameraSensor::CreateCamera()
         std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
         std::placeholders::_4, std::placeholders::_5));
 
-  this->dataPtr->pointCloudConnection =
-      this->dataPtr->depthCamera->ConnectNewRgbPointCloud(
-      std::bind(&DepthCameraSensor::OnNewRgbPointCloud, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-        std::placeholders::_4, std::placeholders::_5));
-
   // Initialize the point message.
   // \todo(anyone) The true value in the following function call forces
   // the xyz and rgb fields to be aligned to memory boundaries. This is need
@@ -534,6 +528,19 @@ bool DepthCameraSensor::Update(
   if (!this->HasDepthConnections() && !this->HasPointConnections())
   {
     return false;
+  }
+
+  if (this->HasPointConnections() && !this->dataPtr->pointCloudConnection)
+  {
+    this->dataPtr->pointCloudConnection =
+        this->dataPtr->depthCamera->ConnectNewRgbPointCloud(
+        std::bind(&DepthCameraSensor::OnNewRgbPointCloud, this,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  }
+  else if (!this->HasPointConnections() && this->dataPtr->pointCloudConnection)
+  {
+    this->dataPtr->pointCloudConnection.reset();
   }
 
   // generate sensor data

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -375,13 +375,6 @@ bool RgbdCameraSensor::CreateCameras()
         std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
         std::placeholders::_4, std::placeholders::_5));
 
-  this->dataPtr->pointCloudConnection =
-      this->dataPtr->depthCamera->ConnectNewRgbPointCloud(
-        std::bind(&RgbdCameraSensorPrivate::OnNewRgbPointCloud,
-        this->dataPtr.get(),
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-        std::placeholders::_4, std::placeholders::_5));
-
   // Set the values of the point message based on the camera information.
   this->dataPtr->pointMsg.set_width(this->ImageWidth());
   this->dataPtr->pointMsg.set_height(this->ImageHeight());
@@ -470,6 +463,22 @@ bool RgbdCameraSensor::Update(const std::chrono::steady_clock::duration &_now)
     !this->HasPointConnections())
   {
     return false;
+  }
+
+  if ((this->HasPointConnections() || HasColorConnections()) &&
+      !this->dataPtr->pointCloudConnection)
+  {
+    this->dataPtr->pointCloudConnection =
+        this->dataPtr->depthCamera->ConnectNewRgbPointCloud(
+        std::bind(&RgbdCameraSensorPrivate::OnNewRgbPointCloud,
+        this->dataPtr.get(),
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+        std::placeholders::_4, std::placeholders::_5));
+  }
+  else if (!this->HasPointConnections() && !this->HasColorConnections() &&
+      this->dataPtr->pointCloudConnection)
+  {
+    this->dataPtr->pointCloudConnection.reset();
   }
 
   unsigned int width = this->dataPtr->depthCamera->ImageWidth();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Related pull request: https://github.com/gazebosim/gz-rendering/pull/965

* Updated DepthCameraSensor and RGBDCameraSensor to connect to the point cloud connection only when there is a subscriber. 

To be used together with https://github.com/gazebosim/gz-rendering/pull/965

Here are the results showing the time taken to perform a [Render()](https://github.com/gazebosim/gz-rendering/blob/7116f01bd5e015cbfc245e55641d8b5fed99f586/ogre2/src/Ogre2DepthCamera.cc#L971) operation by the depth camera in gz-rendering before and after the changes.
* blue line (before) - render time taken is consistent regardless of whether you subscribe to depth or point cloud data.
* red line (after) - I first subscribed to get depth data. After approx 120 iterations, I switched to get rgb point cloud data and you can see the jump in time taken - it still does better than before due to minor optimizations done in: https://github.com/gazebosim/gz-rendering/pull/965

![depth_camera_profile](https://github.com/gazebosim/gz-sensors/assets/4000684/35b500c1-a688-4845-8d28-270212e9b2df)

![rgbd_camera_profile](https://github.com/gazebosim/gz-sensors/assets/4000684/70a57d21-dfdf-4a75-857b-e1da1dc5b33d)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
