### PR TITLE
Fix frames set to Name instead of FrameId for pointclouds

### DIFF
--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -309,7 +309,7 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
   // the xyz and rgb fields to be aligned to memory boundaries. This is need
   // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
   // alignment should be configured.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->Name(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
        {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -134,7 +134,7 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
   // alignment should be configured. This same problem is in the
   // RgbdCameraSensor.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->Name(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
       {"intensity", msgs::PointCloudPacked::Field::FLOAT32},
       {"ring", msgs::PointCloudPacked::Field::UINT16}});


### PR DESCRIPTION
# 🦟 Bug fix

Fixes bug from the https://github.com/gazebosim/gz-sensors/pull/195#issuecomment-1719254639

## Summary
In Gazebo Fortress, pointclouds were still using `Name` to set `frame_id`, making it impossible to overwrite to anything visible by ROS.