### PR TITLE
Add package.xml

### DIFF
--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -6,15 +6,6 @@ on:
 jobs:
   package-xml:
     runs-on: ubuntu-latest
-    name: package.xml and CMake versions match
+    name: Validate package.xml
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check versions
-        run: |
-          echo "Extract version numbers and compare"
-          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-          echo "Version in package.xml: ${package_xml_version}"
-          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-          echo "Version in CMake: ${cmake_version}"
-          [ $package_xml_version = $cmake_version ]
+      - uses: gazebo-tooling/action-gz-ci/validate_package_xml@jammy

--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -1,0 +1,20 @@
+name: Validate package.xml
+
+on:
+  pull_request:
+
+jobs:
+  package-xml:
+    runs-on: ubuntu-latest
+    name: package.xml and CMake versions match
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check versions
+        run: |
+          echo "Extract version numbers and compare"
+          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+          echo "Version in package.xml: ${package_xml_version}"
+          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+          echo "Version in CMake: ${cmake_version}"
+          [ $package_xml_version = $cmake_version ]

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <description>Gazebo Sensors : Sensor models for simulation</description>
   <maintainer email="ichen@openrobotics.org">Ian Chen</maintainer>
   <license>Apache License 2.0</license>
-  <url type="website">https://github.com/gazebosim/gz-fuel-tools</url>
+  <url type="website">https://github.com/gazebosim/gz-sensors</url>
 
   <buildtool_depend>cmake</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>gz-sensors8</name>
+  <version>8.0.1</version>
+  <description>Gazebo Sensors : Sensor models for simulation</description>
+  <maintainer email="ichen@openrobotics.org">Ian Chen</maintainer>
+  <license>Apache License 2.0</license>
+  <url type="website">https://github.com/gazebosim/gz-fuel-tools</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <build_depend>gz-cmake3</build_depend>
+
+  <depend>gz-common5</depend>
+  <depend>gz-math7</depend>
+  <depend>gz-msgs10</depend>
+  <depend>gz-rendering8</depend>
+  <depend>gz-tools2</depend>
+  <depend>gz-transport13</depend>
+  <depend>sdformat14</depend>
+
+  <test_depend>xvfb</test_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add `package.xml` based on dependencies found in `.github/ci/packages`. 

This is to test out using vendor packages to provide Gazebo packages to ROS users (see https://github.com/gazebo-tooling/release-tools/issues/1117). 