### PR TITLE
Suppress unused variable warning

### DIFF
--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1258,7 +1258,7 @@ namespace gz
         // Iterate over the beam solid angle in camera coordinates
         for (auto v = beamScanPatch.YMin(); v < beamScanPatch.YMax(); ++v)
         {
-          (void) _height; // Supress unused warning in variable used below
+          (void) _height;  // Supress unused warning in variable used below
           assert(v >= 0 && v < static_cast<int>(_height));
           const gz::math::Angle inclination =
               v * intrinsics.step.Y() + intrinsics.offset.Y();

--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1258,6 +1258,7 @@ namespace gz
         // Iterate over the beam solid angle in camera coordinates
         for (auto v = beamScanPatch.YMin(); v < beamScanPatch.YMax(); ++v)
         {
+          (void) _height; // Supress unused warning in variable used below
           assert(v >= 0 && v < static_cast<int>(_height));
           const gz::math::Angle inclination =
               v * intrinsics.step.Y() + intrinsics.offset.Y();


### PR DESCRIPTION
# 🦟 Bug fix
Supresses warning shown in gz-sensors main jobs on jammy.

https://build.osrfoundation.org/job/gz_sensors-ci-main-jammy-amd64/59/gcc/

## Summary
The variable is marked as unused by gcc, because it's only used in an assert condition. This will put an extra void statement so the compiler gets the warning suppressed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.