### PR TITLE
Move trigger logic to base Sensor class and enable trigger for all ca…

### DIFF
--- a/include/gz/sensors/BoundingBoxCameraSensor.hh
+++ b/include/gz/sensors/BoundingBoxCameraSensor.hh
@@ -103,10 +103,6 @@ namespace gz
       /// \return True on success.
       private: bool CreateCamera();
 
-      /// \brief Callback for triggered subscription
-      /// \param[in] _msg Boolean message
-      private: void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
-
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -178,10 +178,6 @@ namespace gz
       /// \param[in] _scene Pointer to the new scene.
       private: void OnSceneChange(gz::rendering::ScenePtr /*_scene*/);
 
-      /// \brief Callback for triggered subscription
-      /// \param[in] _msg Boolean message
-      private: void OnTrigger(const gz::msgs::Boolean &/*_msg*/);
-
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -29,6 +29,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <gz/utils/SuppressWarning.hh>
@@ -230,6 +231,30 @@ namespace gz
       /// \brief Check if there are any subscribers
       /// \return True if there are subscribers, false otherwise
       public: virtual bool HasConnections() const;
+
+      /// \brief Set the sensor in triggered mode. In this mode,
+      /// - the sensor will only update if a new message has been published to
+      ///    the passed _trigger_topic since the last update,
+      /// - until the next message is published on _trigger_topic, all Update
+      ///   calls will return false, and
+      /// - update_rate is forced to zero.
+      /// \param[in] _trigger_topic The topic on which the sensor will listen
+      /// for trigger messages.
+      /// \return True if the sensor was successfully set to triggered mode.
+      public: bool EnableTriggered(const std::string &_trigger_topic);
+
+      /// \brief Disable triggered mode. The sensor will update as per the set
+      /// update rate.
+      /// \param[in] _update_rate_hz Optional update rate of sensor in Hertz. If
+      /// std::nullopt is passed, the rate parsed from the SDF will be used if
+      /// it is available, otherwise the update rate will be set to zero.
+      public: void DisableTriggered(
+        const std::optional<double> &_update_rate_hz);
+
+      /// \brief Whether the sensor has a pending trigger.
+      /// \return True if the sensor is in trigger mode and has a pending
+      /// trigger.
+      public: bool HasPendingTrigger() const;
 
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -29,7 +29,6 @@
 
 #include <chrono>
 #include <memory>
-#include <optional>
 #include <string>
 
 #include <gz/utils/SuppressWarning.hh>

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -114,8 +114,8 @@ namespace gz
       ///   subclasses' Update() method will be called.
       /// \param[in] _now The current time
       /// \param[in] _force Force the update to happen even if it's not time
-      /// \return True if the update was triggered (_force was true or _now
-      /// >= next_update_time) and the sensor's
+      /// \return True if the update was performed (_force was true or _now
+      /// >= next_update_time or sensor had a pending trigger) and the sensor's
       /// bool Sensor::Update(std::chrono::steady_clock::time_point)
       /// function returned true.
       /// False otherwise.
@@ -232,24 +232,22 @@ namespace gz
       /// \return True if there are subscribers, false otherwise
       public: virtual bool HasConnections() const;
 
-      /// \brief Set the sensor in triggered mode. In this mode,
+      /// \brief Enable or disable triggered mode. In this mode,
       /// - the sensor will only update if a new message has been published to
-      ///    the passed _trigger_topic since the last update,
-      /// - until the next message is published on _trigger_topic, all Update
+      ///   the passed _triggerTopic since the last update,
+      /// - until the next message is published on _triggerTopic, all Update
       ///   calls will return false, and
-      /// - update_rate is forced to zero.
-      /// \param[in] _trigger_topic The topic on which the sensor will listen
-      /// for trigger messages.
-      /// \return True if the sensor was successfully set to triggered mode.
-      public: bool EnableTriggered(const std::string &_trigger_topic);
-
-      /// \brief Disable triggered mode. The sensor will update as per the set
-      /// update rate.
-      /// \param[in] _update_rate_hz Optional update rate of sensor in Hertz. If
-      /// std::nullopt is passed, the rate parsed from the SDF will be used if
-      /// it is available, otherwise the update rate will be set to zero.
-      public: void DisableTriggered(
-        const std::optional<double> &_update_rate_hz);
+      /// - if the sensor has a pending trigger, the next Update call will
+      ///   ignore the sensor's update rate and try generate data immediately.
+      /// \param[in] _triggered Sets triggered mode if true and disables it if
+      /// false.
+      /// \param[in] _triggerTopic The topic on which the sensor will listen
+      /// for trigger messages in triggered mode. If _triggered is true, this
+      /// value should not be empty. If _triggered is false, this value is
+      /// ignored.
+      /// \return True if the operation succeeded.
+      public: bool SetTriggered(bool _triggered,
+                                const std::string &_triggerTopic = "");
 
       /// \brief Whether the sensor has a pending trigger.
       /// \return True if the sensor is in trigger mode and has a pending

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -231,7 +231,7 @@ bool BoundingBoxCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo())

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -460,7 +460,7 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo())

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -282,6 +282,17 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
   gzdbg << "Depth images for [" << this->Name() << "] advertised on ["
          << this->Topic() << "]" << std::endl;
 
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    std::string triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    if (triggerTopic.empty())
+    {
+      triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
+                                                         "/trigger");
+    }
+    this->EnableTriggered(triggerTopic);
+  }
+
   if (!this->AdvertiseInfo())
     return false;
 

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -290,7 +290,7 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo())

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -245,7 +245,7 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -237,6 +237,17 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
   gzdbg << "Points for [" << this->Name() << "] advertised on ["
          << this->Topic() << "/points]" << std::endl;
 
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    std::string triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    if (triggerTopic.empty())
+    {
+      triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
+                                                         "/trigger");
+    }
+    this->EnableTriggered(triggerTopic);
+  }
+
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;
 

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -223,6 +223,17 @@ bool SegmentationCameraSensor::Load(const sdf::Sensor &_sdf)
     << "] advertised on [" << this->Topic()
     << this->dataPtr->topicLabelsMapSuffix << "]\n";
 
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    std::string triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    if (triggerTopic.empty())
+    {
+      triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
+                                                         "/trigger");
+    }
+    this->EnableTriggered(triggerTopic);
+  }
+
   // TODO(anyone) Access the info topic from the parent class
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -231,7 +231,7 @@ bool SegmentationCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   // TODO(anyone) Access the info topic from the parent class

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -29,14 +29,10 @@
 
 #include "gz/sensors/Sensor.hh"
 
-#include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <map>
 #include <mutex>
-#include <optional>
 #include <ostream>
-#include <vector>
 #include <string>
 
 #include <gz/common/Console.hh>

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -478,8 +478,8 @@ TEST(Sensor_TEST, Trigger)
   EXPECT_DOUBLE_EQ(kUpdateRate, sensor.UpdateRate());
 
   constexpr char kTriggerTopic[] = "/trigger";
-  EXPECT_TRUE(sensor.EnableTriggered(kTriggerTopic));
-  EXPECT_DOUBLE_EQ(0, sensor.UpdateRate());
+  EXPECT_TRUE(sensor.SetTriggered(true, kTriggerTopic));
+  EXPECT_FALSE(sensor.HasPendingTrigger());
 
   transport::Node node;
   transport::Node::Publisher triggerPub =
@@ -509,7 +509,7 @@ TEST(Sensor_TEST, Trigger)
     EXPECT_EQ(preUpdateCount + 1, sensor.updateCount);
   }
 
-  sensor.DisableTriggered(kUpdateRate);
+  sensor.SetTriggered(false);
   EXPECT_DOUBLE_EQ(kUpdateRate, sensor.UpdateRate());
   EXPECT_FALSE(sensor.HasPendingTrigger());
   {

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -19,13 +19,16 @@
   #pragma warning(disable: 4005)
   #pragma warning(disable: 4251)
 #endif
+#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/performance_sensor_metrics.pb.h>
 #if defined(_MSC_VER)
   #pragma warning(pop)
 #endif
 
 #include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -460,5 +463,63 @@ TEST_F(SensorUpdate, NextDataUpdateTime)
     // The next update should be the first dt past the current time
     std::chrono::steady_clock::duration newNext = std::chrono::seconds(6);
     EXPECT_EQ(newNext.count(), sensor->NextDataUpdateTime().count());
+  }
+}
+
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, Trigger)
+{
+  TestSensor sensor;
+  constexpr char kSensorTopic[] = "/topic";
+  EXPECT_TRUE(sensor.SetTopic(kSensorTopic));
+
+  constexpr double kUpdateRate = 5;
+  sensor.SetUpdateRate(5);
+  EXPECT_DOUBLE_EQ(kUpdateRate, sensor.UpdateRate());
+
+  constexpr char kTriggerTopic[] = "/trigger";
+  EXPECT_TRUE(sensor.EnableTriggered(kTriggerTopic));
+  EXPECT_DOUBLE_EQ(0, sensor.UpdateRate());
+
+  transport::Node node;
+  transport::Node::Publisher triggerPub =
+      node.Advertise<msgs::Boolean>(kTriggerTopic);
+
+  {
+    // Before triggering, sensor should not update
+    std::chrono::steady_clock::duration now = std::chrono::seconds(2);
+    std::chrono::steady_clock::duration next = std::chrono::seconds(1);
+    sensor.SetNextDataUpdateTime(next);
+    unsigned int preUpdateCount = sensor.updateCount;
+    EXPECT_FALSE(sensor.Sensor::Update(now, /*_force=*/false));
+    EXPECT_EQ(preUpdateCount, sensor.updateCount);
+  }
+  {
+    // After triggering, sensor should update
+    msgs::Boolean triggerMsg;
+    EXPECT_TRUE(triggerPub.Publish(triggerMsg));
+    while (!sensor.HasPendingTrigger()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::chrono::steady_clock::duration now = std::chrono::seconds(3);
+    std::chrono::steady_clock::duration next = std::chrono::seconds(1);
+    sensor.SetNextDataUpdateTime(next);
+    unsigned int preUpdateCount = sensor.updateCount;
+    EXPECT_TRUE(sensor.Sensor::Update(now, /*_force=*/false));
+    EXPECT_EQ(preUpdateCount + 1, sensor.updateCount);
+  }
+
+  sensor.DisableTriggered(kUpdateRate);
+  EXPECT_DOUBLE_EQ(kUpdateRate, sensor.UpdateRate());
+  EXPECT_FALSE(sensor.HasPendingTrigger());
+  {
+    // Sensor should update according to update rate.
+    std::chrono::steady_clock::duration now = std::chrono::seconds(4);
+    std::chrono::steady_clock::duration next = std::chrono::seconds(1);
+    sensor.SetNextDataUpdateTime(next);
+    unsigned int preUpdateCount = sensor.updateCount;
+    EXPECT_TRUE(sensor.Sensor::Update(now, /*_force=*/false));
+    EXPECT_EQ(preUpdateCount + 1, sensor.updateCount);
+    EXPECT_GE(sensor.NextDataUpdateTime(), now);
   }
 }

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -216,6 +216,17 @@ bool ThermalCameraSensor::Load(const sdf::Sensor &_sdf)
   gzdbg << "Thermal images for [" << this->Name() << "] advertised on ["
          << this->Topic() << "]" << std::endl;
 
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    std::string triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    if (triggerTopic.empty())
+    {
+      triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
+                                                         "/trigger");
+    }
+    this->EnableTriggered(triggerTopic);
+  }
+
   if (!this->AdvertiseInfo())
     return false;
 

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -224,7 +224,7 @@ bool ThermalCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo())

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -193,7 +193,7 @@ bool WideAngleCameraSensor::Load(const sdf::Sensor &_sdf)
       triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
                                                          "/trigger");
     }
-    this->EnableTriggered(triggerTopic);
+    this->SetTriggered(true, triggerTopic);
   }
 
   if (!this->AdvertiseInfo())

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -185,6 +185,17 @@ bool WideAngleCameraSensor::Load(const sdf::Sensor &_sdf)
   gzdbg << "Wide angle camera images for [" << this->Name()
          << "] advertised on [" << this->Topic() << "]" << std::endl;
 
+  if (_sdf.CameraSensor()->Triggered())
+  {
+    std::string triggerTopic = _sdf.CameraSensor()->TriggerTopic();
+    if (triggerTopic.empty())
+    {
+      triggerTopic = transport::TopicUtils::AsValidTopic(this->Topic() +
+                                                         "/trigger");
+    }
+    this->EnableTriggered(triggerTopic);
+  }
+
   if (!this->AdvertiseInfo())
     return false;
 

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -182,7 +182,8 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
     std::string imageTopic =
         "/test/integration/TriggeredBBCameraPlugin_imagesWithBuiltinSDF_image";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(1);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_FALSE(helper.WaitForMessage(1s)) << helper;
     g_mutex.lock();
     EXPECT_EQ(g_boxes.size(), size_t(0));
@@ -204,7 +205,8 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
   {
     WaitForMessageTestHelper<gz::msgs::AnnotatedAxisAligned2DBox_V>
         helper(boxTopic);
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(2);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
     g_mutex.lock();
     EXPECT_EQ(g_boxes.size(), size_t(2));
@@ -286,7 +288,8 @@ void TriggeredBoundingBoxCameraTest::EmptyTriggerTopic(
         "/test/integration/triggered_bbcamera";
     WaitForMessageTestHelper<gz::msgs::AnnotatedAxisAligned2DBox_V>
         helper(boxTopic);
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(1);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
     g_mutex.lock();
     EXPECT_EQ(g_boxes.size(), size_t(2));

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -111,13 +111,15 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   EXPECT_EQ(256u, sensor->ImageWidth());
   EXPECT_EQ(257u, sensor->ImageHeight());
 
-  // check camera image before trigger
+  // Check camera image before trigger. Image should not be published since
+  // the camera has not been triggered yet.
   {
     std::string imageTopic =
         "/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
     EXPECT_TRUE(sensor->HasConnections());
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(1);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_FALSE(helper.WaitForMessage(1s)) << helper;
   }
 
@@ -139,7 +141,8 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
     std::string imageTopic =
         "/test/integration/TriggeredCameraPlugin_imagesWithBuiltinSDF";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(2);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
   }
 
@@ -216,7 +219,8 @@ void TriggeredCameraTest::EmptyTriggerTopic(const std::string &_renderEngine)
     std::string imageTopic =
         "/test/integration/triggered_camera";
     WaitForMessageTestHelper<gz::msgs::Image> helper(imageTopic);
-    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    std::chrono::steady_clock::duration now = std::chrono::seconds(1);
+    mgr.RunOnce(now, /*_force=*/false);
     EXPECT_TRUE(helper.WaitForMessage(10s)) << helper;
   }
 


### PR DESCRIPTION
…mera sensors

# 🦟 Bug fix

Partially addresses https://github.com/gazebosim/gz-sensors/issues/426

## Summary
This PR moves the trigger logic from CameraSensor to the Sensor base class. Additionally, if `Update()` is called with `_force = true`, data will be always generated irrespective of whether a trigger is pending or not. 
To do this, the following changes are made:
- Moved trigger logic to base Sensor class
- Added new Sensor class methods `SetTriggered` and `HasPendingTrigger`
- Set all camera-type sensors to correctly enable triggered mode if it is specified in the SDF
- Update integration tests

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
