### PR TITLE
Set camera projection matrix based on lens params for other types of cameras

### DIFF
--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -148,6 +148,17 @@ namespace gz
       /// \return The camera optical frame
       public: const std::string& OpticalFrameId() const;
 
+      /// \brief Set camera lens intrinsics and projection based on
+      /// values from SDF. If the camera SDF does not contain intrinsic or
+      /// projection parameters, the camera will not be updated. Instead, the
+      /// camera SDF will be updated with intrinsic and projection values
+      /// computed manually from current camera intrinsic properties.
+      /// \param[in] _camera Camera to set intrinsic and projection params.
+      /// \param[in/out] _cameraSdf Camera sdf with intrinisc and projection
+      /// parameters.
+      public: void UpdateLensIntrinsicsAndProjection(
+          rendering::CameraPtr _camera, sdf::Camera &_cameraSdf);
+
       /// \brief Advertise camera info topic.
       /// \return True if successful.
       protected: bool AdvertiseInfo();

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -303,9 +303,6 @@ bool BoundingBoxCameraSensor::CreateCamera()
     return false;
   }
 
-  // Camera Info Msg
-  this->PopulateInfo(sdfCamera);
-
   if (!this->dataPtr->rgbCamera)
   {
     // Create rendering camera
@@ -355,6 +352,14 @@ bool BoundingBoxCameraSensor::CreateCamera()
   // Add the rendering sensors to handle its render
   this->AddSensor(this->dataPtr->boundingboxCamera);
   this->AddSensor(this->dataPtr->rgbCamera);
+
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->rgbCamera,
+      *sdfCamera);
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->boundingboxCamera,
+      *sdfCamera);
+
+  // Camera Info Msg
+  this->PopulateInfo(sdfCamera);
 
   // Create the directory to store frames
   if (sdfCamera->SaveFrames())

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -316,7 +316,7 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
 //////////////////////////////////////////////////
 bool DepthCameraSensor::CreateCamera()
 {
-  const sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
+  sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
 
   if (!cameraSdf)
   {
@@ -330,7 +330,6 @@ bool DepthCameraSensor::CreateCamera()
   double far = cameraSdf->FarClip();
   double near = cameraSdf->NearClip();
 
-  this->PopulateInfo(cameraSdf);
 
   this->dataPtr->depthCamera = this->Scene()->CreateDepthCamera(
       this->Name());
@@ -393,6 +392,9 @@ bool DepthCameraSensor::CreateCamera()
 
   this->Scene()->RootVisual()->AddChild(this->dataPtr->depthCamera);
 
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->depthCamera,
+      *cameraSdf);
+
   // Create the directory to store frames
   if (cameraSdf->SaveFrames())
   {
@@ -400,6 +402,8 @@ bool DepthCameraSensor::CreateCamera()
     this->dataPtr->saveImagePrefix = this->Name() + "_";
     this->dataPtr->saveImage = true;
   }
+
+  this->PopulateInfo(cameraSdf);
 
   this->dataPtr->depthConnection =
       this->dataPtr->depthCamera->ConnectNewDepthFrame(

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -266,15 +266,13 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
 //////////////////////////////////////////////////
 bool RgbdCameraSensor::CreateCameras()
 {
-  const sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
+  sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
 
   if (!cameraSdf)
   {
     gzerr << "Unable to access camera SDF element\n";
     return false;
   }
-
-  this->PopulateInfo(cameraSdf);
 
   int width = cameraSdf->ImageWidth();
   int height = cameraSdf->ImageHeight();
@@ -367,6 +365,11 @@ bool RgbdCameraSensor::CreateCameras()
   // This->dataPtr->distortion->Load(this->dataPtr->sdf->GetElement("distortion"));
 
   this->Scene()->RootVisual()->AddChild(this->dataPtr->depthCamera);
+
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->depthCamera,
+      *cameraSdf);
+
+  this->PopulateInfo(cameraSdf);
 
   this->dataPtr->depthConnection =
       this->dataPtr->depthCamera->ConnectNewDepthFrame(

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -264,7 +264,7 @@ void SegmentationCameraSensor::SetScene(
 /////////////////////////////////////////////////
 bool SegmentationCameraSensor::CreateCamera()
 {
-  const auto sdfCamera = this->dataPtr->sdfSensor.CameraSensor();
+  auto sdfCamera = this->dataPtr->sdfSensor.CameraSensor();
   if (!sdfCamera)
   {
     gzerr << "Unable to access camera SDF element\n";
@@ -292,9 +292,6 @@ bool SegmentationCameraSensor::CreateCamera()
       return false;
     }
   }
-
-  // Camera Info Msg
-  this->PopulateInfo(sdfCamera);
 
   // Save frames properties
   if (sdfCamera->SaveFrames())
@@ -368,6 +365,9 @@ bool SegmentationCameraSensor::CreateCamera()
   // Add the rendering sensor to handle its render
   this->AddSensor(this->dataPtr->camera);
 
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->camera,
+      *sdfCamera);
+
   // Add the rgb camera only if we want to generate dataset / save samples
   if (this->dataPtr->saveSamples)
   {
@@ -385,7 +385,14 @@ bool SegmentationCameraSensor::CreateCamera()
     this->Scene()->RootVisual()->AddChild(this->dataPtr->rgbCamera);
     this->AddSensor(this->dataPtr->rgbCamera);
     this->dataPtr->image = this->dataPtr->rgbCamera->CreateImage();
+
+    this->UpdateLensIntrinsicsAndProjection(this->dataPtr->rgbCamera,
+      *sdfCamera);
   }
+
+  // Camera Info Msg
+  this->PopulateInfo(sdfCamera);
+
 
   // Connection to receive the segmentation buffer
   this->dataPtr->newSegmentationConnection =

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -393,7 +393,6 @@ bool SegmentationCameraSensor::CreateCamera()
   // Camera Info Msg
   this->PopulateInfo(sdfCamera);
 
-
   // Connection to receive the segmentation buffer
   this->dataPtr->newSegmentationConnection =
       this->dataPtr->camera->ConnectNewSegmentationFrame(

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -236,7 +236,7 @@ bool ThermalCameraSensor::Load(const sdf::Sensor &_sdf)
 //////////////////////////////////////////////////
 bool ThermalCameraSensor::CreateCamera()
 {
-  const sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
+  sdf::Camera *cameraSdf = this->dataPtr->sdfSensor.CameraSensor();
 
   if (!cameraSdf)
   {
@@ -251,8 +251,6 @@ bool ThermalCameraSensor::CreateCamera()
 
   double farPlane = cameraSdf->FarClip();
   double nearPlane = cameraSdf->NearClip();
-
-  this->PopulateInfo(cameraSdf);
 
   this->dataPtr->thermalCamera = this->Scene()->CreateThermalCamera(
       this->Name());
@@ -334,6 +332,11 @@ bool ThermalCameraSensor::CreateCamera()
   // This->dataPtr->distortion->Load(this->sdf->GetElement("distortion"));
 
   this->Scene()->RootVisual()->AddChild(this->dataPtr->thermalCamera);
+
+  this->UpdateLensIntrinsicsAndProjection(this->dataPtr->thermalCamera,
+      *cameraSdf);
+
+  this->PopulateInfo(cameraSdf);
 
   // Create the directory to store frames
   if (cameraSdf->SaveFrames())

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -154,6 +154,12 @@ class DepthCameraSensorTest: public testing::Test,
   }
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+
+  // Create depth camera sensors and verify camera intrinsics
+  public: void DepthCameraIntrinsics(const std::string &_renderEngine);
+
+  // Create depth camera sensors and verify camera projection
+  public: void DepthCameraProjection(const std::string &_renderEngine);
 };
 
 void DepthCameraSensorTest::ImagesWithBuiltinSDF(
@@ -512,6 +518,387 @@ TEST_P(DepthCameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
   gz::common::Console::SetVerbosity(4);
+}
+
+//////////////////////////////////////////////////
+void DepthCameraSensorTest::DepthCameraIntrinsics(
+    const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "depth_camera_intrinsics.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+
+  // Camera sensor without intrinsics tag
+  auto cameraWithoutIntrinsicsTag = linkPtr->GetElement("sensor");
+
+  // Camera sensor with intrinsics tag
+  auto cameraWithIntrinsicsTag =
+      linkPtr->GetElement("sensor")->GetNextElement();
+
+  // Camera sensor with different intrinsics tag
+  auto cameraWithDiffIntrinsicsTag =
+      cameraWithIntrinsicsTag->GetNextElement();
+
+  // Setup gz-rendering with an empty scene
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  gz::rendering::VisualPtr root = scene->RootVisual();
+  ASSERT_NE(nullptr, root);
+
+  // create box visual
+  gz::rendering::VisualPtr box = scene->CreateVisual("box");
+  ASSERT_NE(nullptr, box);
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(gz::math::Vector3d(4.0, 1, 0.5));
+  box->SetLocalRotation(0, 0, 0);
+  root->AddChild(box);
+
+  // Do the test
+  gz::sensors::Manager mgr;
+
+  // there are 3 cameras:
+  //     - camera1: no intrinsics params
+  //     - camera2: has intrinsics params that are the same as default values
+  //     - camera3: has intrinsics params that are different from default values
+  // camera1 and camera2 should produce very similar images and camera3 should
+  // produce different images from 1 and 2.
+  auto *sensor1 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithoutIntrinsicsTag);
+  auto *sensor2 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithIntrinsicsTag);
+  auto *sensor3 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithDiffIntrinsicsTag);
+
+  ASSERT_NE(sensor1, nullptr);
+  ASSERT_NE(sensor2, nullptr);
+  ASSERT_NE(sensor3, nullptr);
+  sensor1->SetScene(scene);
+  sensor2->SetScene(scene);
+  sensor3->SetScene(scene);
+
+  std::string infoTopic1 = "/camera1/camera_info";
+  std::string infoTopic2 = "/camera2/camera_info";
+  std::string infoTopic3 = "/camera3/camera_info";
+  std::string imgTopic1 = "/camera1/image";
+  std::string imgTopic2 = "/camera2/image";
+  std::string imgTopic3 = "/camera3/image";
+  WaitForMessageTestHelper<gz::msgs::Image> helper1(imgTopic1);
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper2(infoTopic1);
+  WaitForMessageTestHelper<gz::msgs::Image> helper3(imgTopic2);
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper4(infoTopic2);
+  WaitForMessageTestHelper<gz::msgs::Image> helper5(imgTopic3);
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper6(infoTopic3);
+
+  EXPECT_TRUE(sensor1->HasConnections());
+  EXPECT_TRUE(sensor2->HasConnections());
+  EXPECT_TRUE(sensor3->HasConnections());
+
+  // Update once to create image
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+
+  EXPECT_TRUE(helper1.WaitForMessage()) << helper1;
+  EXPECT_TRUE(helper2.WaitForMessage()) << helper2;
+  EXPECT_TRUE(helper3.WaitForMessage()) << helper3;
+  EXPECT_TRUE(helper4.WaitForMessage()) << helper4;
+  EXPECT_TRUE(helper5.WaitForMessage()) << helper5;
+  EXPECT_TRUE(helper6.WaitForMessage()) << helper6;
+
+  // Subscribe to the camera info topic
+  gz::msgs::CameraInfo camera1Info, camera2Info, camera3Info;
+  unsigned int camera1Counter = 0u;
+  unsigned int camera2Counter = 0u;
+  unsigned int camera3Counter = 0u;
+
+  std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
+      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera1Info = _msg;
+    camera1Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
+      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera2Info = _msg;
+    camera2Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera3InfoCallback =
+      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera3Info = _msg;
+    camera3Counter++;
+  };
+
+  unsigned int height = 1000u;
+  unsigned int width = 1000u;
+  // Subscribe to the camera topic
+  gz::transport::Node node;
+  node.Subscribe(infoTopic1, camera1InfoCallback);
+  node.Subscribe(infoTopic2, camera2InfoCallback);
+  node.Subscribe(infoTopic3, camera3InfoCallback);
+
+  // Wait for a few camera frames
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+
+  // Run to get image and check image format in callback
+  bool done = false;
+  int sleep = 0;
+  int maxSleep = 10;
+  while (!done && sleep++ < maxSleep)
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    done = (camera1Counter > 0u && camera2Counter > 0u && camera3Counter > 0u);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  // Camera sensor without intrinsics tag
+  double error = 3e-1;
+  EXPECT_EQ(camera1Info.width(), width);
+  EXPECT_EQ(camera1Info.height(), height);
+  EXPECT_NEAR(camera1Info.intrinsics().k(0), 866.23, error);
+  EXPECT_NEAR(camera1Info.intrinsics().k(4), 866.23, error);
+  EXPECT_DOUBLE_EQ(camera1Info.intrinsics().k(2), 500);
+  EXPECT_DOUBLE_EQ(camera1Info.intrinsics().k(5), 500);
+
+  // Camera sensor with intrinsics tag
+  EXPECT_EQ(camera2Info.width(), width);
+  EXPECT_EQ(camera2Info.height(), height);
+  EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(0), 866.23);
+  EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(4), 866.23);
+  EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(2), 500);
+  EXPECT_DOUBLE_EQ(camera2Info.intrinsics().k(5), 500);
+
+  // Camera sensor with different intrinsics tag
+  EXPECT_EQ(camera3Info.width(), width);
+  EXPECT_EQ(camera3Info.height(), height);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(0), 900);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(4), 900);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(2), 501);
+  EXPECT_DOUBLE_EQ(camera3Info.intrinsics().k(5), 501);
+
+  // Clean up rendering ptrs
+  box.reset();
+
+  // Clean up
+  mgr.Remove(sensor1->Id());
+  mgr.Remove(sensor2->Id());
+  mgr.Remove(sensor3->Id());
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(DepthCameraSensorTest, CameraIntrinsics)
+{
+  gz::common::Console::SetVerbosity(2);
+  DepthCameraIntrinsics(GetParam());
+}
+
+//////////////////////////////////////////////////
+void DepthCameraSensorTest::DepthCameraProjection(
+    const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "depth_camera_projection.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+
+  // Camera sensor without projection tag
+  auto cameraWithoutProjectionsTag = linkPtr->GetElement("sensor");
+
+  // Camera sensor with projection tag
+  auto cameraWithProjectionsTag =
+      linkPtr->GetElement("sensor")->GetNextElement();
+
+  // Camera sensor with different projection tag
+  auto cameraWithDiffProjectionsTag =
+      cameraWithProjectionsTag->GetNextElement();
+
+  // Setup gz-rendering with an empty scene
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  gz::rendering::VisualPtr root = scene->RootVisual();
+  ASSERT_NE(nullptr, root);
+
+  // create box visual
+  gz::rendering::VisualPtr box = scene->CreateVisual("box");
+  ASSERT_NE(nullptr, box);
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(gz::math::Vector3d(4.0, 1, 0.5));
+  box->SetLocalRotation(0, 0, 0);
+  root->AddChild(box);
+
+  // Do the test
+  gz::sensors::Manager mgr;
+
+  auto *sensor1 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithoutProjectionsTag);
+  auto *sensor2 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithProjectionsTag);
+  auto *sensor3 = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(
+      cameraWithDiffProjectionsTag);
+
+  ASSERT_NE(sensor1, nullptr);
+  ASSERT_NE(sensor2, nullptr);
+  ASSERT_NE(sensor3, nullptr);
+  std::string imgTopic1 = "/camera1/image";
+  std::string imgTopic2 = "/camera2/image";
+  std::string imgTopic3 = "/camera3/image";
+  sensor1->SetScene(scene);
+  sensor2->SetScene(scene);
+  sensor3->SetScene(scene);
+
+  std::string infoTopic1 = "/camera1/camera_info";
+  std::string infoTopic2 = "/camera2/camera_info";
+  std::string infoTopic3 = "/camera3/camera_info";
+  WaitForMessageTestHelper<gz::msgs::Image> helper1("/camera1/image");
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper2(infoTopic1);
+  WaitForMessageTestHelper<gz::msgs::Image> helper3("/camera2/image");
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper4(infoTopic2);
+  WaitForMessageTestHelper<gz::msgs::Image> helper5(imgTopic3);
+  WaitForMessageTestHelper<gz::msgs::CameraInfo> helper6(infoTopic3);
+
+  EXPECT_TRUE(sensor1->HasConnections());
+  EXPECT_TRUE(sensor2->HasConnections());
+  EXPECT_TRUE(sensor3->HasConnections());
+
+  // Update once to create image
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+
+  EXPECT_TRUE(helper1.WaitForMessage()) << helper1;
+  EXPECT_TRUE(helper2.WaitForMessage()) << helper2;
+  EXPECT_TRUE(helper3.WaitForMessage()) << helper3;
+  EXPECT_TRUE(helper4.WaitForMessage()) << helper4;
+  EXPECT_TRUE(helper5.WaitForMessage()) << helper5;
+  EXPECT_TRUE(helper6.WaitForMessage()) << helper6;
+
+  // Subscribe to the camera info topic
+  gz::msgs::CameraInfo camera1Info, camera2Info, camera3Info;
+  unsigned int camera1Counter = 0u;
+  unsigned int camera2Counter = 0u;
+  unsigned int camera3Counter = 0u;
+
+  std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
+      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera1Info = _msg;
+    camera1Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
+      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera2Info = _msg;
+    camera2Counter++;
+  };
+  std::function<void(const gz::msgs::CameraInfo&)> camera3InfoCallback =
+      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo& _msg)
+  {
+    camera3Info = _msg;
+    camera3Counter++;
+  };
+
+  unsigned int height = 1000u;
+  unsigned int width = 1000u;
+
+  // Subscribe to the camera topic
+  gz::transport::Node node;
+  node.Subscribe(infoTopic1, camera1InfoCallback);
+  node.Subscribe(infoTopic2, camera2InfoCallback);
+  node.Subscribe(infoTopic3, camera3InfoCallback);
+
+  // Wait for a few camera frames
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+
+  // Run to get image and check image format in callback
+  bool done = false;
+  int sleep = 0;
+  int maxSleep = 10;
+  while (!done && sleep++ < maxSleep)
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    done = (camera1Counter > 0u && camera2Counter > 0u && camera3Counter > 0u);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  // Camera sensor without projection tag
+  // account for error converting gl projection values back to
+  // cv projection values
+  double error = 1.0;
+  EXPECT_EQ(camera1Info.width(), width);
+  EXPECT_EQ(camera1Info.height(), height);
+  EXPECT_NEAR(camera1Info.projection().p(0), 866.23, error);
+  EXPECT_NEAR(camera1Info.projection().p(5), 866.23, error);
+  EXPECT_DOUBLE_EQ(camera1Info.projection().p(2), 500.0);
+  EXPECT_DOUBLE_EQ(camera1Info.projection().p(6), 500.0);
+  EXPECT_DOUBLE_EQ(camera1Info.projection().p(3), 0.0);
+  EXPECT_DOUBLE_EQ(camera1Info.projection().p(7), 0.0);
+
+  // Camera sensor with projection tag
+  EXPECT_EQ(camera2Info.width(), width);
+  EXPECT_EQ(camera2Info.height(), height);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(0), 866.23);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(5), 866.23);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(2), 500.0);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(6), 500.0);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(3), 300.0);
+  EXPECT_DOUBLE_EQ(camera2Info.projection().p(7), 200.0);
+
+  // Camera sensor with different projection tag
+  EXPECT_EQ(camera3Info.width(), width);
+  EXPECT_EQ(camera3Info.height(), height);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(0), 900.0);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(5), 900.0);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(2), 501.0);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(6), 501.0);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(3), 0.0);
+  EXPECT_DOUBLE_EQ(camera3Info.projection().p(7), 0.0);
+
+  // Clean up rendering ptrs
+  box.reset();
+
+  // Clean up
+  mgr.Remove(sensor1->Id());
+  mgr.Remove(sensor2->Id());
+  mgr.Remove(sensor3->Id());
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(DepthCameraSensorTest, CameraProjection)
+{
+  gz::common::Console::SetVerbosity(2);
+  DepthCameraProjection(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(DepthCameraSensor, DepthCameraSensorTest,

--- a/test/sdf/depth_camera_intrinsics.sdf
+++ b/test/sdf/depth_camera_intrinsics.sdf
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera_without_intrinsics_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera1/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+      </sensor>
+      <sensor name="camera_with_intrinsics_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera2/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <intrinsics>
+              <fx>866.23</fx>
+              <fy>866.23</fy>
+              <cx>500</cx>
+              <cy>500</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+        </camera>
+      </sensor>
+      <sensor name="camera_with_diff_intrinsics_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera3/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <intrinsics>
+              <fx>900</fx>
+              <fy>900</fy>
+              <cx>501</cx>
+              <cy>501</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+        </camera>
+      </sensor>
+
+    </link>
+  </model>
+</sdf>

--- a/test/sdf/depth_camera_projection.sdf
+++ b/test/sdf/depth_camera_projection.sdf
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera_without_projection_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera1/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+        </camera>
+      </sensor>
+      <sensor name="camera_with_projection_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera2/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <lens>
+            <projection>
+              <p_fx>866.23</p_fx>
+              <p_fy>866.23</p_fy>
+              <p_cx>500</p_cx>
+              <p_cy>500</p_cy>
+              <tx>300</tx>
+              <ty>200</ty>
+            </projection>
+          </lens>
+        </camera>
+      </sensor>
+      <sensor name="camera_with_diff_projection_tag" type="depth">
+        <update_rate>10</update_rate>
+        <gz_frame_id>base_camera</gz_frame_id>
+        <topic>/camera3/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <lens>
+            <projection>
+              <p_fx>900</p_fx>
+              <p_fy>900</p_fy>
+              <p_cx>501</p_cx>
+              <p_cy>501</p_cy>
+              <tx>0</tx>
+              <ty>0</ty>
+            </projection>
+          </lens>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION


# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gz-rendering/issues/968

## Summary

For camera types other than `camera`, e.g. `depth_camera`, the input camera sdf's lens `<intrinsics>` or `<projection>` parameters were not used. This PR refactor's the base CameraSensor class' logic for parsing and setting custom projection matrix in to a new function named `UpdateLensIntrinsicsAndProjection()`. The derived camera classes now call this function for setting a custom projection matrix if needed.

Added tests to verify the intrinsic params published through the camera info topic for depth camera sensors.

Here is a test [camera_projection.sdf](https://gist.github.com/iche033/b9a3d4cb749b71fb635bcf087bb5d271) world file. Together with https://github.com/gazebosim/gz-rendering/pull/1002, a depth camera should now produce the same image / FOV as a regular camera when intrinsics or projection param are specified in the sdf.

Before: Cameras have different FOV.
<img width="699" alt="depth_camera_projection_before" src="https://github.com/gazebosim/gz-sensors/assets/4000684/005890f5-9552-462e-b6d8-153534d91e65">

After: Depth camera has the same horizontal FOV as a regular camera
<img width="706" alt="depth_camera_projection_after" src="https://github.com/gazebosim/gz-sensors/assets/4000684/b6052c3a-856b-4554-9147-ba0df8d4875e">


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

