### PR TITLE
Set rendering sensor pose

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -321,6 +321,8 @@ bool BoundingBoxCameraSensor::CreateCamera()
   this->dataPtr->boundingboxCamera->SetVisibilityMask(
     sdfCamera->VisibilityMask());
   this->dataPtr->boundingboxCamera->SetBoundingBoxType(this->dataPtr->type);
+  this->dataPtr->boundingboxCamera->SetLocalPose(
+      this->Pose() * sdfCamera->RawPose());
 
   // Add the camera to the scene
   this->Scene()->RootVisual()->AddChild(this->dataPtr->rgbCamera);

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -321,8 +321,7 @@ bool BoundingBoxCameraSensor::CreateCamera()
   this->dataPtr->boundingboxCamera->SetVisibilityMask(
     sdfCamera->VisibilityMask());
   this->dataPtr->boundingboxCamera->SetBoundingBoxType(this->dataPtr->type);
-  this->dataPtr->boundingboxCamera->SetLocalPose(
-      this->Pose() * sdfCamera->RawPose());
+  this->dataPtr->boundingboxCamera->SetLocalPose(this->Pose());
 
   // Add the camera to the scene
   this->Scene()->RootVisual()->AddChild(this->dataPtr->rgbCamera);

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -212,6 +212,7 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetNearClipPlane(cameraSdf->NearClip());
   this->dataPtr->camera->SetFarClipPlane(cameraSdf->FarClip());
   this->dataPtr->camera->SetVisibilityMask(cameraSdf->VisibilityMask());
+  this->dataPtr->camera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
   this->AddSensor(this->dataPtr->camera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {
@@ -452,9 +453,6 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
   }
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-
-  // move the camera to the current pose
-  this->dataPtr->camera->SetLocalPose(this->Pose());
 
   if (this->HasInfoConnections())
   {

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -212,7 +212,7 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetNearClipPlane(cameraSdf->NearClip());
   this->dataPtr->camera->SetFarClipPlane(cameraSdf->FarClip());
   this->dataPtr->camera->SetVisibilityMask(cameraSdf->VisibilityMask());
-  this->dataPtr->camera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
+  this->dataPtr->camera->SetLocalPose(this->Pose());
   this->AddSensor(this->dataPtr->camera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -350,7 +350,7 @@ bool DepthCameraSensor::CreateCamera()
   this->dataPtr->depthCamera->SetFarClipPlane(far);
   this->dataPtr->depthCamera->SetVisibilityMask(
       cameraSdf->VisibilityMask());
-  this->dataPtr->depthCamera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
+  this->dataPtr->depthCamera->SetLocalPose(this->Pose());
   this->AddSensor(this->dataPtr->depthCamera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -350,7 +350,7 @@ bool DepthCameraSensor::CreateCamera()
   this->dataPtr->depthCamera->SetFarClipPlane(far);
   this->dataPtr->depthCamera->SetVisibilityMask(
       cameraSdf->VisibilityMask());
-
+  this->dataPtr->depthCamera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
   this->AddSensor(this->dataPtr->depthCamera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -194,9 +194,6 @@ bool GpuLidarSensor::CreateLidar()
     return false;
   }
 
-  this->dataPtr->gpuRays->SetWorldPosition(this->Pose().Pos());
-  this->dataPtr->gpuRays->SetWorldRotation(this->Pose().Rot());
-
   this->dataPtr->gpuRays->SetNearClipPlane(this->RangeMin());
   this->dataPtr->gpuRays->SetFarClipPlane(this->RangeMax());
 
@@ -214,6 +211,7 @@ bool GpuLidarSensor::CreateLidar()
   this->dataPtr->gpuRays->SetRayCount(this->RayCount());
   this->dataPtr->gpuRays->SetVerticalRayCount(
       this->VerticalRayCount());
+  this->dataPtr->gpuRays->SetLocalPose(this->Pose());
 
   this->Scene()->RootVisual()->AddChild(
       this->dataPtr->gpuRays);

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -326,8 +326,7 @@ bool RgbdCameraSensor::CreateCameras()
   }
 
   this->dataPtr->depthCamera->SetVisibilityMask(cameraSdf->VisibilityMask());
-  this->dataPtr->depthCamera->SetLocalPose(
-      this->Pose() * cameraSdf->RawPose());
+  this->dataPtr->depthCamera->SetLocalPose(this->Pose());
 
   this->AddSensor(this->dataPtr->depthCamera);
 

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -326,6 +326,8 @@ bool RgbdCameraSensor::CreateCameras()
   }
 
   this->dataPtr->depthCamera->SetVisibilityMask(cameraSdf->VisibilityMask());
+  this->dataPtr->depthCamera->SetLocalPose(
+      this->Pose() * cameraSdf->RawPose());
 
   this->AddSensor(this->dataPtr->depthCamera);
 

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -369,7 +369,7 @@ bool SegmentationCameraSensor::CreateCamera()
   this->dataPtr->camera->SetFarClipPlane(sdfCamera->FarClip());
   this->dataPtr->camera->SetAspectRatio(aspectRatio);
   this->dataPtr->camera->SetHFOV(angle);
-  this->dataPtr->camera->SetLocalPose(this->Pose() * sdfCamera->RawPose());
+  this->dataPtr->camera->SetLocalPose(this->Pose());
 
   // Add the camera to the scene
   this->Scene()->RootVisual()->AddChild(this->dataPtr->camera);

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -369,6 +369,7 @@ bool SegmentationCameraSensor::CreateCamera()
   this->dataPtr->camera->SetFarClipPlane(sdfCamera->FarClip());
   this->dataPtr->camera->SetAspectRatio(aspectRatio);
   this->dataPtr->camera->SetHFOV(angle);
+  this->dataPtr->camera->SetLocalPose(this->Pose() * sdfCamera->RawPose());
 
   // Add the camera to the scene
   this->Scene()->RootVisual()->AddChild(this->dataPtr->camera);

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -300,8 +300,7 @@ bool ThermalCameraSensor::CreateCamera()
   this->dataPtr->thermalCamera->SetMinTemperature(this->dataPtr->minTemp);
   this->dataPtr->thermalCamera->SetMaxTemperature(this->dataPtr->maxTemp);
   this->dataPtr->thermalCamera->SetLinearResolution(this->dataPtr->resolution);
-  this->dataPtr->thermalCamera->SetLocalPose(
-      this->Pose() * cameraSdf->RawPose());
+  this->dataPtr->thermalCamera->SetLocalPose(this->Pose());
   this->AddSensor(this->dataPtr->thermalCamera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -300,7 +300,8 @@ bool ThermalCameraSensor::CreateCamera()
   this->dataPtr->thermalCamera->SetMinTemperature(this->dataPtr->minTemp);
   this->dataPtr->thermalCamera->SetMaxTemperature(this->dataPtr->maxTemp);
   this->dataPtr->thermalCamera->SetLinearResolution(this->dataPtr->resolution);
-
+  this->dataPtr->thermalCamera->SetLocalPose(
+      this->Pose() * cameraSdf->RawPose());
   this->AddSensor(this->dataPtr->thermalCamera);
 
   const std::map<SensorNoiseType, sdf::Noise> noises = {

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -240,7 +240,7 @@ bool WideAngleCameraSensor::CreateCamera()
   this->dataPtr->camera->SetNearClipPlane(cameraSdf->NearClip());
   this->dataPtr->camera->SetFarClipPlane(cameraSdf->FarClip());
   this->dataPtr->camera->SetVisibilityMask(cameraSdf->VisibilityMask());
-  this->dataPtr->camera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
+  this->dataPtr->camera->SetLocalPose(this->Pose());
 
   rendering::CameraLens lens;
   std::string lensType = cameraSdf->LensType();

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -240,6 +240,7 @@ bool WideAngleCameraSensor::CreateCamera()
   this->dataPtr->camera->SetNearClipPlane(cameraSdf->NearClip());
   this->dataPtr->camera->SetFarClipPlane(cameraSdf->FarClip());
   this->dataPtr->camera->SetVisibilityMask(cameraSdf->VisibilityMask());
+  this->dataPtr->camera->SetLocalPose(this->Pose() * cameraSdf->RawPose());
 
   rendering::CameraLens lens;
   std::string lensType = cameraSdf->LensType();
@@ -412,9 +413,6 @@ bool WideAngleCameraSensor::Update(
     gzerr << "WideAngleCamera doesn't exist.\n";
     return false;
   }
-
-  // move the camera to the current pose
-  this->dataPtr->camera->SetLocalPose(this->Pose());
 
   // render only if necessary
   if (!this->dataPtr->pub.HasConnections() &&


### PR DESCRIPTION
# 🦟 Bug fix

Related PR: https://github.com/gazebosim/gz-sim/pull/2425

## Summary

When most of the rendering sensors are created, I realized that we do not actually set the pose of the internal rendering sensor objects anywhere in gz-sensors. Instead we currently rely on gz-sim to update these poses on every iteration. This PR now sets the sensor pose on creation. It removes pose updates in relevant `Update` functions if any. ~~Additionally for camera based sensors, the final pose of the camera sensor is the combined result of both `//sensor/pose` and `//sensor/camera/pose`.~~ **Update**: No longer setting final pose to take into account `//sensor/camera/pose`, see https://github.com/gazebosim/gz-sim/pull/2433#issuecomment-2150894010 - planning to deprecate / remove this tag. 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

