### PR TITLE
Add API to check if sensor is in trigger mode

### DIFF
--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -253,6 +253,10 @@ namespace gz
       /// trigger.
       public: bool HasPendingTrigger() const;
 
+      /// \brief Whether the sensor trigger mode is enabled.
+      /// \return True if the sensor is in trigger mode, false otherwise
+      public: bool IsTriggered() const;
+
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -653,10 +653,17 @@ void SensorPrivate::DisableTriggered() {
 }
 
 //////////////////////////////////////////////////
-bool Sensor::HasPendingTrigger() const {
+bool Sensor::HasPendingTrigger() const
+{
   if (!this->dataPtr->IsTriggered())
     return false;
 
   std::lock_guard<std::mutex> triggerLock(this->dataPtr->triggerMutex);
   return this->dataPtr->pendingTrigger;
+}
+
+//////////////////////////////////////////////////
+bool Sensor::IsTriggered() const
+{
+  return this->dataPtr->IsTriggered();
 }

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -477,8 +477,10 @@ TEST(Sensor_TEST, Trigger)
   sensor.SetUpdateRate(5);
   EXPECT_DOUBLE_EQ(kUpdateRate, sensor.UpdateRate());
 
+  EXPECT_FALSE(sensor.IsTriggered());
   constexpr char kTriggerTopic[] = "/trigger";
   EXPECT_TRUE(sensor.SetTriggered(true, kTriggerTopic));
+  EXPECT_TRUE(sensor.IsTriggered());
   EXPECT_FALSE(sensor.HasPendingTrigger());
 
   transport::Node node;


### PR DESCRIPTION

# 🎉 New feature



## Summary

Added `Sensor::IsTriggered` function.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
