### PR TITLE
Fix boundingbox_camera integration test

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -338,7 +338,7 @@ bool BoundingBoxCameraSensor::CreateCamera()
       sdfCameraCopy);
   this->UpdateLensIntrinsicsAndProjection(this->dataPtr->boundingboxCamera,
       *sdfCamera);
-    // Camera Info Msg
+  // Camera Info Msg
   this->PopulateInfo(sdfCamera);
 
   // Create the directory to store frames

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -331,12 +331,14 @@ bool BoundingBoxCameraSensor::CreateCamera()
   this->AddSensor(this->dataPtr->boundingboxCamera);
   this->AddSensor(this->dataPtr->rgbCamera);
 
+  // use a copy so we do not modify the original sdfCamera
+  // when updating bounding box camera
+  auto sdfCameraCopy = *sdfCamera;
   this->UpdateLensIntrinsicsAndProjection(this->dataPtr->rgbCamera,
-      *sdfCamera);
+      sdfCameraCopy);
   this->UpdateLensIntrinsicsAndProjection(this->dataPtr->boundingboxCamera,
       *sdfCamera);
-
-  // Camera Info Msg
+    // Camera Info Msg
   this->PopulateInfo(sdfCamera);
 
   // Create the directory to store frames


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #440

## Summary

test was broken by #432. The call to `UpdateLensIntrinsicsAndProjection` makes changes to camera sdf which causes the second call to think that the bounding box camera needs to use a custom projection matrix. So the fix is to use a copy for the first call instead.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
