### PR TITLE
Use //sensor/frame_id sdf element

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -691,6 +691,9 @@ void CameraSensor::PopulateInfo(const sdf::Camera *_cameraSdf)
   // To make this configurable the user has the option to set an optical frame.
   // If the user has set <optical_frame_id> in the cameraSdf use it,
   // otherwise fall back to the sensor frame.
+  // \todo(iche033 sdf::Camera::OpticalFrameId is deprecated.
+  // Remove this if statement when gz-sensors is updated to use sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   if (_cameraSdf->OpticalFrameId().empty())
   {
    this->dataPtr->opticalFrameId = this->FrameId();
@@ -699,6 +702,8 @@ void CameraSensor::PopulateInfo(const sdf::Camera *_cameraSdf)
   {
    this->dataPtr->opticalFrameId = _cameraSdf->OpticalFrameId();
   }
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
   auto infoFrame = this->dataPtr->infoMsg.mutable_header()->add_data();
   infoFrame->set_key("frame_id");
   infoFrame->add_value(this->dataPtr->opticalFrameId);

--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1946,6 +1946,9 @@ namespace gz
         if (this->dataPtr->publishingEstimates)
         {
           auto * headerMessage = bottomModeMessage.mutable_header();
+          auto frame = headerMessage->add_data();
+          frame->set_key("frame_id");
+          frame->add_value(this->FrameId());
           this->AddSequence(headerMessage, "doppler_velocity_log");
           this->dataPtr->pub.Publish(bottomModeMessage);
         }
@@ -1965,6 +1968,9 @@ namespace gz
         if (this->dataPtr->publishingEstimates)
         {
           auto * headerMessage = waterMassModeMessage.mutable_header();
+          auto frame = headerMessage->add_data();
+          frame->set_key("frame_id");
+          frame->add_value(this->FrameId());
           this->AddSequence(headerMessage, "doppler_velocity_log");
           this->dataPtr->pub.Publish(waterMassModeMessage);
         }

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -134,7 +134,7 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
   // alignment should be configured. This same problem is in the
   // RgbdCameraSensor.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->Name(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
       {"intensity", msgs::PointCloudPacked::Field::FLOAT32},
       {"ring", msgs::PointCloudPacked::Field::UINT16}});

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -302,6 +302,9 @@ bool RgbdCameraSensor::CreateCameras()
   // To make this configurable the user has the option to set an optical frame.
   // If the user has set <optical_frame_id> in the cameraSdf use it,
   // otherwise fall back to the sensor frame.
+  // \todo(iche033 sdf::Camera::OpticalFrameId is deprecated.
+  // Remove this if statement when gz-sensors is updated to use sdformat16
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
   if (cameraSdf->OpticalFrameId().empty())
   {
    this->dataPtr->opticalFrameId = this->FrameId();
@@ -310,6 +313,7 @@ bool RgbdCameraSensor::CreateCameras()
   {
    this->dataPtr->opticalFrameId = cameraSdf->OpticalFrameId();
   }
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   // Depth camera clip params are new and only override the camera clip
   // params if specified.

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -138,7 +138,7 @@ class gz::sensors::SensorPrivate
   public: std::map<std::string, uint64_t> sequences;
 
   /// \brief frame id
-  public: std::string frame_id;
+  public: std::string frameId;
 
   /// \brief If sensor is active or not.
   public: bool active = true;
@@ -161,9 +161,6 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
 {
   this->sdfSensor = _sdf;
 
-  // All SDF code gets auto converted to latest version. This code is
-  // written assuming sdformat 1.7 is the latest
-
   // \todo(nkoenig) what to do with <always_on>? SDFormat docs seem
   // to say if true
   //  then the update_rate will be obeyed. Gazebo seems to use it as if
@@ -174,7 +171,6 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   // sensor data. Whether or not that data should be visualized seems to
   // be outside the scope of this library
 
-  // \todo(nkoenig) how to use frame?
   this->name = _sdf.Name();
   if (!_sdf.Topic().empty())
   {
@@ -182,16 +178,22 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
       return false;
   }
 
-  sdf::ElementPtr element = _sdf.Element();
-  if (element)
+  this->frameId = _sdf.FrameId();
+  if (this->frameId.empty())
   {
-    if (element->HasElement("gz_frame_id"))
+    sdf::ElementPtr element = _sdf.Element();
+    if (element)
     {
-      this->frame_id = element->Get<std::string>("gz_frame_id");
-    }
-    else
-    {
-      this->frame_id = this->name;
+      if (element->HasElement("gz_frame_id"))
+      {
+        gzwarn << "//sensor/gz_frame_id is deprecated. "
+               << "Please use //sensor/frame_id instead. " << std::endl;
+        this->frameId = element->Get<std::string>("gz_frame_id");
+      }
+      else
+      {
+        this->frameId = this->name;
+      }
     }
   }
 
@@ -288,13 +290,13 @@ std::string Sensor::Name() const
 //////////////////////////////////////////////////
 std::string Sensor::FrameId() const
 {
-  return this->dataPtr->frame_id;
+  return this->dataPtr->frameId;
 }
 
 //////////////////////////////////////////////////
 void Sensor::SetFrameId(const std::string &_frameId)
 {
-  this->dataPtr->frame_id = _frameId;
+  this->dataPtr->frameId = _frameId;
 }
 
 //////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -390,15 +390,17 @@ TEST(Sensor_TEST, FrameIdFromSdf)
   {
     TestSensor testSensor;
     loadSensorWithSdfParam(testSensor,
-                           "<gz_frame_id>custom_frame_id</gz_frame_id>");
+                           "<frame_id>custom_frame_id</frame_id>");
     EXPECT_EQ("custom_frame_id", testSensor.FrameId());
   }
+  // todo(iche033)
+  // Remove when gz-sensors is updated to use sdformat16
   {
     TestSensor testSensor;
     loadSensorWithSdfParam(testSensor, R"(
-      <ignition_frame_id>custom_frame_id</ignition_frame_id>
+      <frame_id>custom_frame_id</frame_id>
       <gz_frame_id>other_custom_frame_id</gz_frame_id>)");
-    EXPECT_EQ("other_custom_frame_id", testSensor.FrameId());
+    EXPECT_EQ("custom_frame_id", testSensor.FrameId());
   }
 }
 //////////////////////////////////////////////////

--- a/test/integration/dvl.cc
+++ b/test/integration/dvl.cc
@@ -45,6 +45,7 @@ using DopplerVelocityLog = sensors::DopplerVelocityLog;
 struct DVLConfig
 {
   std::string name = "dvl";
+  std::string frameId = "dvl_frame";
   std::string topic = "/gz/sensors/test/dvl";
   double updateRate = 30;  // Hz
 
@@ -75,6 +76,7 @@ sdf::ElementPtr MakeDVLSdf(const DVLConfig &_config)
     << " <model name='model'>"
     << "  <link name='link'>"
     << "   <sensor name='" << _config.name << "' type='custom' gz:type='dvl'>"
+    << "    <frame_id>" << _config.frameId << "</frame_id>"
     << "    <always_on>" << _config.alwaysOn << "</always_on>"
     << "    <update_rate>" << _config.updateRate << "</update_rate>"
     << "    <topic>" << _config.topic << "</topic>"
@@ -345,6 +347,13 @@ TEST_P(DopplerVelocityLogTest, BottomTrackingWhileStatic)
   }
   EXPECT_EQ(0, message.status());
 
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
+
   this->manager.Remove(sensor->Id());
 }
 
@@ -436,6 +445,13 @@ TEST_P(DopplerVelocityLogTest, WaterMassTrackingWhileStatic)
   }
   EXPECT_EQ(0, message.status());
 
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
+
   this->manager.Remove(sensor->Id());
 }
 
@@ -518,6 +534,13 @@ TEST_P(DopplerVelocityLogTest, BottomTrackingWhileInMotion)
     EXPECT_EQ(velocityReference, message.beams(i).velocity().reference());
   }
   EXPECT_EQ(0, message.status());
+
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
 
   this->manager.Remove(sensor->Id());
 }

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -65,7 +65,7 @@ sdf::ElementPtr GpuLidarToSdf(const std::string &name,
     const double vertResolution, const double vertMinAngle,
     const double vertMaxAngle, const double rangeResolution,
     const double rangeMin, const double rangeMax, const bool alwaysOn,
-    const bool visualize)
+    const bool visualize, const std::string &frameId)
 {
   std::ostringstream stream;
   stream
@@ -74,6 +74,7 @@ sdf::ElementPtr GpuLidarToSdf(const std::string &name,
     << " <model name='m1'>"
     << "  <link name='link1'>"
     << "    <sensor name='" << name << "' type='gpu_lidar'>"
+    << "      <frame_id>" << frameId << "</frame_id>"
     << "      <pose>" << pose << "</pose>"
     << "      <topic>" << topic << "</topic>"
     << "      <updateRate>"<< updateRate <<"</updateRate>"
@@ -194,6 +195,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
 
   // Create sensor description in SDF
   gz::math::Pose3d testPose(gz::math::Vector3d(0, 0, 0.1),
@@ -201,7 +203,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
@@ -313,6 +315,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
 
   // Create sensor SDF
   gz::math::Pose3d testPose(gz::math::Vector3d(0.0, 0.0, 0.1),
@@ -320,7 +323,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create and populate scene
   gz::rendering::RenderEngine *engine =
@@ -399,7 +402,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
       LASER_TOL);
   EXPECT_DOUBLE_EQ(laserMsgs.back().ranges(last), gz::math::INF_D);
 
-  EXPECT_EQ(laserMsgs.back().frame(), name);
+  EXPECT_EQ(laserMsgs.back().frame(), frameId);
   EXPECT_NEAR(laserMsgs.back().angle_min(), horzMinAngle, 1e-4);
   EXPECT_NEAR(laserMsgs.back().angle_max(), horzMaxAngle, 1e-4);
   EXPECT_NEAR(laserMsgs.back().count(), horzSamples, 1e-4);
@@ -424,6 +427,12 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   EXPECT_EQ(32u * horzSamples, pointMsgs.back().row_step());
   EXPECT_FALSE(pointMsgs.back().is_dense());
   EXPECT_EQ(32u * horzSamples * vertSamples, pointMsgs.back().data().size());
+
+  EXPECT_TRUE(pointMsgs.back().has_header());
+  EXPECT_LT(1, pointMsgs.back().header().data().size());
+  EXPECT_EQ("frame_id", pointMsgs.back().header().data(0).key());
+  ASSERT_EQ(1, pointMsgs.back().header().data(0).value().size());
+  EXPECT_EQ(frameId, pointMsgs.back().header().data(0).value(0));
 
   // Clean up rendering ptrs
   visualBox1.reset();
@@ -462,6 +471,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
 
   // Create sensor SDF
   gz::math::Pose3d testPose1(gz::math::Vector3d(0, 0, 0.1),
@@ -469,7 +479,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf1 = GpuLidarToSdf(name1, testPose1, updateRate,
       topic1, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create a second sensor SDF rotated
   gz::math::Pose3d testPose2(gz::math::Vector3d(0, 0, 0.1),
@@ -477,7 +487,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf2 = GpuLidarToSdf(name2, testPose2, updateRate,
       topic2, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create and populate scene
   gz::rendering::RenderEngine *engine =
@@ -618,6 +628,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
 
   // Create sensor SDF
   gz::math::Pose3d testPose(gz::math::Vector3d(0.25, 0.0, 0.5),
@@ -625,7 +636,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+    rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create and populate scene
   gz::rendering::RenderEngine *engine =
@@ -745,6 +756,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
 
   // Create sensor SDF
   gz::math::Pose3d testPose1(gz::math::Vector3d(0, 0, 0.1),
@@ -752,7 +764,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf1 = GpuLidarToSdf(name1, testPose1, updateRate,
       topic1, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create a second sensor SDF at an xy offset of 1
   gz::math::Pose3d testPose2(gz::math::Vector3d(1, 1, 0.1),
@@ -760,7 +772,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   sdf::ElementPtr lidarSdf2 = GpuLidarToSdf(name2, testPose2, updateRate,
       topic2, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
   // Create and populate scene
   gz::rendering::RenderEngine *engine =
@@ -870,6 +882,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
   const double rangeMax = 10.0;
   const bool alwaysOn = 1;
   const bool visualize = 1;
+  const std::string frameId = "TestGpuLidar_frame";
   auto testPose = gz::math::Pose3d();
 
   // Scene
@@ -892,7 +905,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
     auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
       horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
     auto lidar = mgr.CreateSensor<gz::sensors::GpuLidarSensor>(lidarSdf);
     ASSERT_NE(nullptr, lidar);
@@ -906,7 +919,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
     auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
       horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
     auto lidar = mgr.CreateSensor<gz::sensors::GpuLidarSensor>(lidarSdf);
     ASSERT_NE(nullptr, lidar);
@@ -921,7 +934,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
     auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
       horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
-      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize, frameId);
 
     auto sensor = mgr.CreateSensor<gz::sensors::GpuLidarSensor>(lidarSdf);
     EXPECT_EQ(nullptr, sensor);

--- a/test/sdf/camera_intrinsics.sdf
+++ b/test/sdf/camera_intrinsics.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_without_intrinsics_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera1/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -21,7 +21,7 @@
       </sensor>
       <sensor name="camera_with_intrinsics_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera2/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -47,7 +47,7 @@
       </sensor>
       <sensor name="camera_with_diff_intrinsics_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera3/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>

--- a/test/sdf/camera_projection.sdf
+++ b/test/sdf/camera_projection.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_without_projection_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera1/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -17,7 +17,7 @@
       </sensor>
       <sensor name="camera_with_projection_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera2/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -40,7 +40,7 @@
       </sensor>
       <sensor name="camera_with_diff_projection_tag" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera3/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>

--- a/test/sdf/camera_sensor_builtin.sdf
+++ b/test/sdf/camera_sensor_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera1" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/test/integration/CameraPlugin_imagesWithBuiltinSDF</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/camera_sensor_l16_builtin.sdf
+++ b/test/sdf/camera_sensor_l16_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera1" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/images_l16</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/camera_sensor_l8_l16_builtin.sdf
+++ b/test/sdf/camera_sensor_l8_l16_builtin.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_8_bit" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/images_l8</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>
@@ -26,7 +26,7 @@
       </sensor>
       <sensor name="camera_16_bit" type="camera">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/images_l16</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>

--- a/test/sdf/depth_camera_intrinsics.sdf
+++ b/test/sdf/depth_camera_intrinsics.sdf
@@ -4,7 +4,7 @@
     <link name="link1">
       <sensor name="camera_without_intrinsics_tag" type="depth">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera1/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -20,7 +20,7 @@
       </sensor>
       <sensor name="camera_with_intrinsics_tag" type="depth">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera2/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>
@@ -45,7 +45,7 @@
       </sensor>
       <sensor name="camera_with_diff_intrinsics_tag" type="depth">
         <update_rate>10</update_rate>
-        <gz_frame_id>base_camera</gz_frame_id>
+        <frame_id>base_camera</frame_id>
         <topic>/camera3/image</topic>
         <camera>
           <horizontal_fov>1.0472</horizontal_fov>


### PR DESCRIPTION

# 🎉 New feature

Related issue: https://github.com/gazebosim/gz-sensors/issues/306
Depends on: https://github.com/gazebosim/sdformat/pull/1454

## Summary

The different ways of specifying sensor frame id are being deprecated. This PR makes use of the new //sensor/frame_id sdf element introduced in https://github.com/gazebosim/sdformat/pull/1454. It also deprecates the use of the custom `<gz_frame_id>` tag. If both tags exist, `<frame_id>` will override `<gz_frame_id>`


## Test it

All test files have been updated to use `<frame_id>` instead of `<gz_frame_id>` and the affected integration tests should pass, e.g. depth, thermal, rgbd camera integration tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

