### PR TITLE
Port frame_id fixes from #444

### DIFF
--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1945,6 +1945,9 @@ namespace gz
         if (this->dataPtr->publishingEstimates)
         {
           auto * headerMessage = bottomModeMessage.mutable_header();
+          auto frame = headerMessage->add_data();
+          frame->set_key("frame_id");
+          frame->add_value(this->FrameId());
           this->AddSequence(headerMessage, "doppler_velocity_log");
           this->dataPtr->pub.Publish(bottomModeMessage);
         }
@@ -1964,6 +1967,9 @@ namespace gz
         if (this->dataPtr->publishingEstimates)
         {
           auto * headerMessage = waterMassModeMessage.mutable_header();
+          auto frame = headerMessage->add_data();
+          frame->set_key("frame_id");
+          frame->add_value(this->FrameId());
           this->AddSequence(headerMessage, "doppler_velocity_log");
           this->dataPtr->pub.Publish(waterMassModeMessage);
         }

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -134,7 +134,7 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
   // alignment should be configured. This same problem is in the
   // RgbdCameraSensor.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->Name(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
       {"intensity", msgs::PointCloudPacked::Field::FLOAT32},
       {"ring", msgs::PointCloudPacked::Field::UINT16}});

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -138,7 +138,7 @@ class gz::sensors::SensorPrivate
   public: std::map<std::string, uint64_t> sequences;
 
   /// \brief frame id
-  public: std::string frame_id;
+  public: std::string frameId;
 
   /// \brief If sensor is active or not.
   public: bool active = true;
@@ -187,11 +187,11 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   {
     if (element->HasElement("gz_frame_id"))
     {
-      this->frame_id = element->Get<std::string>("gz_frame_id");
+      this->frameId = element->Get<std::string>("gz_frame_id");
     }
     else
     {
-      this->frame_id = this->name;
+      this->frameId = this->name;
     }
   }
 
@@ -288,13 +288,13 @@ std::string Sensor::Name() const
 //////////////////////////////////////////////////
 std::string Sensor::FrameId() const
 {
-  return this->dataPtr->frame_id;
+  return this->dataPtr->frameId;
 }
 
 //////////////////////////////////////////////////
 void Sensor::SetFrameId(const std::string &_frameId)
 {
-  this->dataPtr->frame_id = _frameId;
+  this->dataPtr->frameId = _frameId;
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/dvl.cc
+++ b/test/integration/dvl.cc
@@ -45,6 +45,7 @@ using DopplerVelocityLog = sensors::DopplerVelocityLog;
 struct DVLConfig
 {
   std::string name = "dvl";
+  std::string frameId = "dvl_frame";
   std::string topic = "/gz/sensors/test/dvl";
   double updateRate = 30;  // Hz
 
@@ -75,6 +76,7 @@ sdf::ElementPtr MakeDVLSdf(const DVLConfig &_config)
     << " <model name='model'>"
     << "  <link name='link'>"
     << "   <sensor name='" << _config.name << "' type='custom' gz:type='dvl'>"
+    << "    <gz_frame_id>" << _config.frameId << "</gz_frame_id>"
     << "    <always_on>" << _config.alwaysOn << "</always_on>"
     << "    <update_rate>" << _config.updateRate << "</update_rate>"
     << "    <topic>" << _config.topic << "</topic>"
@@ -345,6 +347,13 @@ TEST_P(DopplerVelocityLogTest, BottomTrackingWhileStatic)
   }
   EXPECT_EQ(0, message.status());
 
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
+
   this->manager.Remove(sensor->Id());
 }
 
@@ -436,6 +445,13 @@ TEST_P(DopplerVelocityLogTest, WaterMassTrackingWhileStatic)
   }
   EXPECT_EQ(0, message.status());
 
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
+
   this->manager.Remove(sensor->Id());
 }
 
@@ -518,6 +534,13 @@ TEST_P(DopplerVelocityLogTest, BottomTrackingWhileInMotion)
     EXPECT_EQ(velocityReference, message.beams(i).velocity().reference());
   }
   EXPECT_EQ(0, message.status());
+
+  // check frame id
+  EXPECT_TRUE(message.has_header());
+  EXPECT_LT(1, message.header().data().size());
+  EXPECT_EQ("frame_id", message.header().data(0).key());
+  ASSERT_EQ(1, message.header().data(0).value().size());
+  EXPECT_EQ("dvl_frame", message.header().data(0).value(0));
 
   this->manager.Remove(sensor->Id());
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Partial backport of #444. Ported changes that fix missing / incorrect DVL and GpuLidar frame_ids

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
