### PR TITLE
Publish lidar scan only if there are lidar scan connections

### DIFF
--- a/include/gz/sensors/Lidar.hh
+++ b/include/gz/sensors/Lidar.hh
@@ -244,6 +244,13 @@ namespace gz
       /// \return Visibility mask
       public: uint32_t VisibilityMask() const;
 
+      /// \brief Clamp a finite range value to min / max range.
+      /// +/-inf values will not be clamped because they mean lidar returns are
+      /// outside the detectable range.
+      /// NAN values will be clamped to max range.
+      /// \return Clamped range value.
+      private: double Clamp(double _range) const;
+
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Just a mutex for thread safety
       public: mutable std::mutex lidarMutex;

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
 */
+
+#include <algorithm>
+
 #if defined(_MSC_VER)
   #pragma warning(push)
   #pragma warning(disable: 4005)
@@ -450,7 +453,8 @@ double Lidar::Range(const int _index) const
 
   // \todo(iche033) interpolate if ray count != range count, i.e. resolution > 1
   if (!this->laserBuffer || _index >= static_cast<int>(
-      this->RayCount() * this->VerticalRayCount() * this->dataPtr->kChannelCount))
+      this->RayCount() * this->VerticalRayCount() *
+      this->dataPtr->kChannelCount))
   {
     gzwarn << "Lidar range not available for index: " << _index << std::endl;
     return 0.0;
@@ -466,7 +470,8 @@ double Lidar::Retro(const int _index) const
 
   // \todo(iche033) interpolate if ray count != range count, i.e. resolution > 1
   if (!this->laserBuffer || _index >= static_cast<int>(
-      this->RayCount() * this->VerticalRayCount() * this->dataPtr->kChannelCount))
+      this->RayCount() * this->VerticalRayCount() *
+      this->dataPtr->kChannelCount))
   {
     gzwarn << "Lidar retro not available for index: " << _index << std::endl;
     return 0.0;
@@ -507,7 +512,7 @@ double Lidar::Clamp(double _range) const
     return this->RangeMax();
 
   if (std::isfinite(_range))
-    return gz::math::clamp(_range, this->RangeMin(), this->RangeMax());
+    return std::clamp(_range, this->RangeMin(), this->RangeMax());
 
   return _range;
 }

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -348,6 +348,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   visualBox1->AddGeometry(scene->CreateBox());
   visualBox1->SetLocalPosition(box01Pose.Pos());
   visualBox1->SetLocalRotation(box01Pose.Rot());
+  visualBox1->SetUserData("laser_retro", 123);
   root->AddChild(visualBox1);
 
   // Create a sensor manager
@@ -380,6 +381,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   // Sensor 1 should see TestBox1
   EXPECT_DOUBLE_EQ(sensor->Range(0), gz::math::INF_D);
   EXPECT_NEAR(sensor->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
+  EXPECT_NEAR(123, sensor->Retro(mid), 1e-1);
   EXPECT_DOUBLE_EQ(sensor->Range(last), gz::math::INF_D);
 
   // Make sure to wait to receive the message
@@ -412,6 +414,12 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   EXPECT_NEAR(laserMsgs.back().vertical_count(), vertSamples, 1e-4);
   EXPECT_NEAR(laserMsgs.back().range_min(), rangeMin, 1e-4);
   EXPECT_NEAR(laserMsgs.back().range_max(), rangeMax, 1e-4);
+
+  EXPECT_TRUE(laserMsgs.back().has_header());
+  EXPECT_LT(1, laserMsgs.back().header().data().size());
+  EXPECT_EQ("frame_id", laserMsgs.back().header().data(0).key());
+  ASSERT_EQ(1, laserMsgs.back().header().data(0).value().size());
+  EXPECT_EQ(frameId, laserMsgs.back().header().data(0).value(0));
 
   ASSERT_TRUE(!pointMsgs.empty());
   EXPECT_EQ(5, pointMsgs.back().field_size());


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

The GpuLidarSensor publishes to 2 topics: 1) lidar scan and 2) points cloud. Previously if the user subscribes to just the point cloud topic, we perform extra computation to pack and publish lidar scans as well. This PR adds an additional check to make sure we don't do extra work when there are not lidar scan subscribers.

In order to make this work, I also had to modify functions for directly accessing lidar scan data. They were accessing the lidar scan msg (which now never gets populated if there are no subscribers), so I modified them to access data from the raw laser buffer instead.

I also fixed the frame id for the lidar scan msg.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

