### PR TITLE
ForceTorqueSensor: add API for newest measurement

### DIFF
--- a/include/gz/sensors/ForceTorqueSensor.hh
+++ b/include/gz/sensors/ForceTorqueSensor.hh
@@ -26,6 +26,8 @@
 
 #include <gz/math/Pose3.hh>
 
+#include <gz/msgs/wrench.pb.h>
+
 #include <gz/sensors/config.hh>
 #include <gz/sensors/force_torque/Export.hh>
 
@@ -92,6 +94,11 @@ namespace gz
       /// applied on the child (parent-to-child)
       /// \param[in] _torque torque vector in newton.
       public: void SetTorque(const math::Vector3d &_torque);
+
+      /// \brief Get the most recent wrench measurement. This matches the data
+      /// published over the gz-transport topic.
+      /// \return The most recent wrench measurement.
+      public: const msgs::Wrench &MeasuredWrench() const;
 
       /// \brief Set the rotation of the joint parent relative to the sensor
       /// frame.

--- a/src/ForceTorqueSensor.cc
+++ b/src/ForceTorqueSensor.cc
@@ -95,6 +95,10 @@ class gz::sensors::ForceTorqueSensorPrivate
 ForceTorqueSensor::ForceTorqueSensor()
   : dataPtr(std::make_unique<ForceTorqueSensorPrivate>())
 {
+  // measuredWrench is reused, so allocate the first header data-value pair
+  auto frame = this->dataPtr->measuredWrench.mutable_header()->add_data();
+  frame->set_key("frame_id");
+  frame->add_value("");
 }
 
 //////////////////////////////////////////////////
@@ -252,9 +256,10 @@ bool ForceTorqueSensor::Update(const std::chrono::steady_clock::duration &_now)
 
   msgs::Wrench &msg = this->dataPtr->measuredWrench;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
-  auto frame = msg.mutable_header()->add_data();
-  frame->set_key("frame_id");
-  frame->add_value(this->FrameId());
+  auto frame = msg.mutable_header()->mutable_data(0);
+  // header.data[0].key is already set to "frame_id" in the constructor
+  // header.data[0].value[0] is already allocated in the constructor
+  frame->set_value(0, this->FrameId());
 
   msgs::Set(msg.mutable_force(), measuredForce);
   msgs::Set(msg.mutable_torque(), measuredTorque);

--- a/src/ForceTorqueSensor.cc
+++ b/src/ForceTorqueSensor.cc
@@ -55,6 +55,9 @@ class gz::sensors::ForceTorqueSensorPrivate
   /// \brief Noise free torque as set by SetTorque
   public: gz::math::Vector3d torque{0, 0, 0};
 
+  /// \brief Most recent wrench measurement.
+  public: gz::msgs::Wrench measuredWrench;
+
   /// \brief Frame in which we return the measured force torque info.
   public: sdf::ForceTorqueFrame measureFrame;
 
@@ -247,7 +250,7 @@ bool ForceTorqueSensor::Update(const std::chrono::steady_clock::duration &_now)
   applyNoise(TORQUE_Y_NOISE_N_M, measuredTorque.Y());
   applyNoise(TORQUE_Z_NOISE_N_M, measuredTorque.Z());
 
-  msgs::Wrench msg;
+  msgs::Wrench &msg = this->dataPtr->measuredWrench;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
@@ -286,6 +289,12 @@ math::Vector3d ForceTorqueSensor::Torque() const
 void ForceTorqueSensor::SetTorque(const math::Vector3d &_torque)
 {
   this->dataPtr->torque = _torque;
+}
+
+//////////////////////////////////////////////////
+const msgs::Wrench &ForceTorqueSensor::MeasuredWrench() const
+{
+  return this->dataPtr->measuredWrench;
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/force_torque.cc
+++ b/test/integration/force_torque.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 
 #include <sdf/ForceTorque.hh>
@@ -245,6 +246,9 @@ TEST_P(ForceTorqueSensorTest, SensorReadings)
   sensor->Update(dt, false);
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
   auto msg = msgHelper.Message();
+  EXPECT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(
+          msg, sensor->MeasuredWrench()));
   EXPECT_EQ(1, msg.header().stamp().sec());
   EXPECT_EQ(0, msg.header().stamp().nsec());
 


### PR DESCRIPTION
# 🎉 New feature

Needed for https://github.com/gazebosim/gz-sim/issues/2268 and https://github.com/gazebosim/gz-sim/issues/2391.

## Summary

Currently the wrench data published by gz-transport is not available via the C++ API. This pull request adds an accessor to the most recent `Wrench` message that is identical to that published on gz-transport.

## Test it

Build and run `bin/INTEGRATION_force_torque`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
