### PR TITLE
Optimization: skip applying noise and distortion to lidars and camera sensors if parameters are 0s

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -224,12 +224,20 @@ bool CameraSensor::CreateCamera()
     // Add gaussian noise to camera sensor
     if (noiseSdf.Type() == sdf::NoiseType::GAUSSIAN)
     {
-      this->dataPtr->noises[noiseType] =
-        ImageNoiseFactory::NewNoiseModel(noiseSdf, "camera");
+      // Skip applying noise if mean and stddev are 0 - this avoids
+      // doing an extra render pass in gz-rendering
+      // Note ImageGaussianNoiseModel only uses mean and stddev and does not
+      // use bias parameters.
+      if (!math::equal(noiseSdf.Mean(), 0.0) ||
+          !math::equal(noiseSdf.StdDev(), 0.0))
+      {
+        this->dataPtr->noises[noiseType] =
+          ImageNoiseFactory::NewNoiseModel(noiseSdf, "camera");
 
-      std::dynamic_pointer_cast<ImageGaussianNoiseModel>(
-           this->dataPtr->noises[noiseType])->SetCamera(
-             this->dataPtr->camera);
+        std::dynamic_pointer_cast<ImageGaussianNoiseModel>(
+             this->dataPtr->noises[noiseType])->SetCamera(
+               this->dataPtr->camera);
+      }
     }
     else if (noiseSdf.Type() != sdf::NoiseType::NONE)
     {
@@ -253,13 +261,22 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetHFOV(angle);
 
   if (cameraSdf->Element() != nullptr &&
-      cameraSdf->Element()->HasElement("distortion")) {
-    this->dataPtr->distortion =
-        ImageDistortionFactory::NewDistortionModel(*cameraSdf, "camera");
-    this->dataPtr->distortion->Load(*cameraSdf);
+      cameraSdf->Element()->HasElement("distortion"))
+  {
+    // Skip distortion of all coefficients are 0s
+    if (!math::equal(cameraSdf->DistortionK1(), 0.0) ||
+        !math::equal(cameraSdf->DistortionK2(), 0.0) ||
+        !math::equal(cameraSdf->DistortionK3(), 0.0) ||
+        !math::equal(cameraSdf->DistortionP1(), 0.0) ||
+        !math::equal(cameraSdf->DistortionP2(), 0.0))
+    {
+      this->dataPtr->distortion =
+          ImageDistortionFactory::NewDistortionModel(*cameraSdf, "camera");
+      this->dataPtr->distortion->Load(*cameraSdf);
 
-    std::dynamic_pointer_cast<ImageBrownDistortionModel>(
-        this->dataPtr->distortion)->SetCamera(this->dataPtr->camera);
+      std::dynamic_pointer_cast<ImageBrownDistortionModel>(
+          this->dataPtr->distortion)->SetCamera(this->dataPtr->camera);
+    }
   }
 
   sdf::PixelFormatType pixelFormat = cameraSdf->PixelFormat();

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -172,8 +172,16 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
   {
     if (noiseSdf.Type() == sdf::NoiseType::GAUSSIAN)
     {
-      this->dataPtr->noises[noiseType] =
-        NoiseFactory::NewNoiseModel(noiseSdf);
+      // Skip applying noise if gaussian noise params are all 0s
+      if (!math::equal(noiseSdf.Mean(), 0.0) ||
+          !math::equal(noiseSdf.StdDev(), 0.0) ||
+          !math::equal(noiseSdf.BiasMean(), 0.0) ||
+          !math::equal(noiseSdf.DynamicBiasStdDev(), 0.0) ||
+          !math::equal(noiseSdf.DynamicBiasCorrelationTime(), 0.0))
+      {
+        this->dataPtr->noises[noiseType] =
+          NoiseFactory::NewNoiseModel(noiseSdf);
+      }
     }
     else if (noiseSdf.Type() != sdf::NoiseType::NONE)
     {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

When Gaussian noise params and distortion coefficients are 0s, there shouldn't be any change to the sensor output. So skip doing extra computations in this case. 

One instance where this usually happens is when a user saves the world to file in gz-sim, all sdf elements are written out with their default values. So when you load the saved world sdf file back in, you now have noise / distortion sdf elements present but with values of 0s.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

