### PR TITLE
Fix frame_id in rgbd_camera

### DIFF
--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -251,15 +251,6 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;
 
-  // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
-      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
-       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
-
   if (this->Scene())
   {
     this->CreateCameras();
@@ -389,6 +380,15 @@ bool RgbdCameraSensor::CreateCameras()
         this->dataPtr.get(),
         std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
         std::placeholders::_4, std::placeholders::_5));
+
+  // Initialize the point message.
+  // \todo(anyone) The true value in the following function call forces
+  // the xyz and rgb fields to be aligned to memory boundaries. This is need
+  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
+  // alignment should be configured.
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(), true,
+      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
+       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 
   // Set the values of the point message based on the camera information.
   this->dataPtr->pointMsg.set_width(this->ImageWidth());

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -386,7 +386,8 @@ bool RgbdCameraSensor::CreateCameras()
   // the xyz and rgb fields to be aligned to memory boundaries. This is need
   // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
   // alignment should be configured.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(),
+      true,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
        {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes [No number]

## Summary

When using rgbd_camera as sensor, `frame_id` is filled with `FrameId()` (for example `tiago/head_2_link/head_front_camera_frame_sensor`), instead of `OpticalFrameId()` (for example, `head_front_camera_rgb_optical_frame`). So, the `frame_id` in the messages is wrong.

This PR fixes it.

I hope it helps. Any comment is welcome :)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


