### PR TITLE
Fix SphericalCoordinate deprecation warning in DVL sensor

### DIFF
--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1731,7 +1731,7 @@ namespace gz
               samplePointInSensorFrame;
 
           // Transform sample point to the environmental data frame
-          std::optional<gz::math::CoordinateVector3>
+          const std::optional<gz::math::CoordinateVector3>
               samplePointInDataFrameCoordVec =
               this->worldState->origin.PositionTransform(
                   gz::math::CoordinateVector3::Metric(samplePointInWorldFrame),

--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1731,11 +1731,33 @@ namespace gz
               samplePointInSensorFrame;
 
           // Transform sample point to the environmental data frame
-          const gz::math::Vector3d samplePointInDataFrame =
+          std::optional<gz::math::CoordinateVector3>
+              samplePointInDataFrameCoordVec =
               this->worldState->origin.PositionTransform(
-                  samplePointInWorldFrame,
+                  gz::math::CoordinateVector3::Metric(samplePointInWorldFrame),
                   gz::math::SphericalCoordinates::GLOBAL,
                   this->waterVelocityReference);
+
+          if (!samplePointInDataFrameCoordVec.has_value())
+            continue;
+
+          gz::math::Vector3d samplePointInDataFrame;
+          if (samplePointInDataFrameCoordVec->IsSpherical())
+          {
+            samplePointInDataFrame.Set(
+                samplePointInDataFrameCoordVec->Lat()->Radian(),
+                samplePointInDataFrameCoordVec->Lon()->Radian(),
+                *samplePointInDataFrameCoordVec->Z());
+          }
+          else if (samplePointInDataFrameCoordVec->IsMetric())
+          {
+            samplePointInDataFrame =
+                *samplePointInDataFrameCoordVec->AsMetricVector();
+          }
+          else
+          {
+            continue;
+          }
 
           // Sample water velocity in the world frame at sample point
           const gz::math::Vector3d sampledVelocityInWorldFrame =


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Fixed deprecation warning by updating the `gz::math::SphericalCoordinate::PositionTransform` call to use the new `gz::math::CoordinateVector3` arg introduced in https://github.com/gazebosim/gz-math/pull/616. 

cc @peci1 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

