### PR TITLE
Backport fix for optical_frame_id in Depth and RGBD camera sensors

### DIFF
--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -153,6 +153,10 @@ namespace ignition
       /// \todo(iche033) Make this function virtual on Harmonic
       public: bool HasInfoConnections() const;
 
+      /// \brief Get the camera optical frame
+      /// \return The camera optical frame
+      public: const std::string &OpticalFrameId() const;
+
       /// \brief Advertise camera info topic.
       /// \return True if successful.
       protected: bool AdvertiseInfo();

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -896,6 +896,12 @@ bool CameraSensor::HasInfoConnections() const
 }
 
 //////////////////////////////////////////////////
+const std::string &CameraSensor::OpticalFrameId() const
+{
+  return this->dataPtr->opticalFrameId;
+}
+
+//////////////////////////////////////////////////
 math::Matrix4d CameraSensorPrivate::BuildProjectionMatrix(
     double _imageWidth, double _imageHeight,
     double _intrinsicsFx, double _intrinsicsFy,

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -304,15 +304,6 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
   igndbg << "Points for [" << this->Name() << "] advertised on ["
          << this->Topic() << "/points]" << std::endl;
 
-  // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
-      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
-       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
-
   if (this->Scene())
   {
     this->CreateCamera();
@@ -426,6 +417,18 @@ bool DepthCameraSensor::CreateCamera()
       std::bind(&DepthCameraSensor::OnNewRgbPointCloud, this,
         std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
         std::placeholders::_4, std::placeholders::_5));
+
+  // Initialize the point message.
+  // \todo(anyone) The true value in the following function call forces
+  // the xyz and rgb fields to be aligned to memory boundaries. This is need
+  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
+  // alignment should be configured.
+  msgs::InitPointCloudPacked(
+      this->dataPtr->pointMsg,
+      this->OpticalFrameId(),
+      true,
+      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
+       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 
   // Set the values of the point message based on the camera information.
   this->dataPtr->pointMsg.set_width(this->ImageWidth());
@@ -554,9 +557,10 @@ bool DepthCameraSensor::Update(
                rendering::PF_FLOAT32_R));
   msg.set_pixel_format_type(msgsFormat);
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
+
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameId());
+  frame->add_value(this->OpticalFrameId());
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   msg.set_data(this->dataPtr->depthBuffer,

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -247,15 +247,6 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;
 
-  // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
-      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
-       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
-
   if (this->Scene())
   {
     this->CreateCameras();
@@ -388,6 +379,16 @@ bool RgbdCameraSensor::CreateCameras()
         this->dataPtr.get(),
         std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
         std::placeholders::_4, std::placeholders::_5));
+
+  // Initialize the point message.
+  // \todo(anyone) The true value in the following function call forces
+  // the xyz and rgb fields to be aligned to memory boundaries. This is need
+  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
+  // alignment should be configured.
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(),
+      true,
+      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
+       {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 
   // Set the values of the point message based on the camera information.
   this->dataPtr->pointMsg.set_width(this->ImageWidth());


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Port `<optical_frame_id>` fixes from https://github.com/gazebosim/gz-sensors/pull/458 and https://github.com/gazebosim/gz-sensors/pull/362 for DepthCamera and RGBD camera sensors.

To test:

Run with this exampel [optical_frame_id.sdf](https://gist.github.com/iche033/a925f9567640fbbdb5b3601bc96013c7) world and check the frame_id field in various topics.

```bash
ign gazebo -v 4 -s -r optical_frame_id.sdf
```

```bash
# check rgbd camera topics: the `frame_id` value should be `rgbd_optical_frame_id`
ign topic -e -t /rgbd/camera_info  | grep -A 2 frame_id
ign topic -e -t /rgbd/image  | grep -A 2 frame_id
ign topic -e -t /rgbd/depth_image  | grep -A 2 frame_id
ign topic -e -t /rgbd/points  | grep -A 2 frame_id

# check depth camera topics: the `frame_id` value should be `depth_optical_frame_id`
ign topic -e -t /camera_info  | grep -A 2 frame_id
ign topic -e -t /depth/points | grep -A 2 frame_id
ign topic -e -t /depth | grep -A 2 frame_id
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
