### PR TITLE
Add links to subsequent tutorials

### DIFF
--- a/tutorials/custom_sensors.md
+++ b/tutorials/custom_sensors.md
@@ -1,5 +1,7 @@
 \page custom_sensors Custom sensors
 
+Next Tutorial: \ref thermalcameraigngazebo
+
 Gazebo Sensors comes with various built-in sensor types ready to be used.
 Users aren't limited to those sensor types though. This tutorial will go over
 the process of implementing a custom sensor that leverages Gazebo Sensors

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -1,5 +1,7 @@
 \page installation Installation
 
+Next Tutorial: \ref custom_sensors
+
 We recommend following the binary install instructions to get up and running as quickly and painlessly as possible.
 
 The source install instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.

--- a/tutorials/segmentation_camera.md
+++ b/tutorials/segmentation_camera.md
@@ -1,5 +1,7 @@
 \page segmentationcamera_igngazebo Segmentation Camera in Gazebo
 
+Next Tutorial: \ref boundingbox_camera
+
 In this tutorial, we will discuss how to use a segmentation camera sensor in Gazebo.
 
 ## Requirements

--- a/tutorials/thermal_camera.md
+++ b/tutorials/thermal_camera.md
@@ -1,5 +1,7 @@
 \page thermalcameraigngazebo Thermal Camera in Gazebo
 
+Next Tutorial: \ref segmentationcamera_igngazebo
+
 In this tutorial, we will discuss how to use a thermal camera sensor in [Gazebo](https://gazebosim.org/libs/sim).
 
 There are currently a few limitations with the thermal camera, which will be mentioned at the end of the tutorial.


### PR DESCRIPTION
Update tutorial pages to include a link to the next tutorial. Addresses https://github.com/gazebosim/gazebo_test_cases/issues/1510#issuecomment-2324526093

This is similar to what already exists in [intro.md](https://github.com/gazebosim/gz-sensors/blob/c1abfed3a116e439196ab511657b9d954ea42e2b/tutorials/intro.md?plain=1#L3)