### PR TITLE
Check camera sensors have non-zero width or height

### DIFF
--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -293,6 +293,13 @@ bool BoundingBoxCameraSensor::CreateCamera()
   auto width = sdfCamera->ImageWidth();
   auto height = sdfCamera->ImageHeight();
 
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a bounding box camera sensor with 0 width or "
+          << "height. " << std::endl;
+    return false;
+  }
+
   // Set Camera Properties
   this->dataPtr->rgbCamera->SetImageFormat(rendering::PF_R8G8B8);
   this->dataPtr->rgbCamera->SetImageWidth(width);

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -144,6 +144,13 @@ bool CameraSensor::CreateCamera()
   unsigned int width = cameraSdf->ImageWidth();
   unsigned int height = cameraSdf->ImageHeight();
 
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a camera sensor with 0 width or height."
+          << std::endl;
+    return false;
+  }
+
   this->dataPtr->camera = this->Scene()->CreateCamera(this->Name());
   this->dataPtr->camera->SetImageWidth(width);
   this->dataPtr->camera->SetImageHeight(height);

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -337,8 +337,15 @@ bool DepthCameraSensor::CreateCamera()
     return false;
   }
 
-  int width = cameraSdf->ImageWidth();
-  int height = cameraSdf->ImageHeight();
+  unsigned int width = cameraSdf->ImageWidth();
+  unsigned int height = cameraSdf->ImageHeight();
+
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a depth camera sensor with 0 width or height."
+          << std::endl;
+    return false;
+  }
 
   double far = cameraSdf->FarClip();
   double near = cameraSdf->NearClip();

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -278,8 +278,15 @@ bool RgbdCameraSensor::CreateCameras()
     return false;
   }
 
-  int width = cameraSdf->ImageWidth();
-  int height = cameraSdf->ImageHeight();
+  unsigned int width = cameraSdf->ImageWidth();
+  unsigned int height = cameraSdf->ImageHeight();
+
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create an RGBD camera sensor with 0 width or height."
+          << std::endl;
+    return false;
+  }
 
   this->dataPtr->depthCamera =
       this->Scene()->CreateDepthCamera(this->Name());

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -353,6 +353,13 @@ bool SegmentationCameraSensor::CreateCamera()
   auto width = sdfCamera->ImageWidth();
   auto height = sdfCamera->ImageHeight();
 
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a segmentation camera sensor with 0 width or "
+          << "height." << std::endl;
+    return false;
+  }
+
   math::Angle angle = sdfCamera->HorizontalFov();
   if (angle < 0.01 || angle > GZ_PI*2)
   {

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -255,8 +255,15 @@ bool ThermalCameraSensor::CreateCamera()
     return false;
   }
 
-  int width = cameraSdf->ImageWidth();
-  int height = cameraSdf->ImageHeight();
+  unsigned int width = cameraSdf->ImageWidth();
+  unsigned int height = cameraSdf->ImageHeight();
+
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a thermal camera sensor with 0 width or height."
+          << std::endl;
+    return false;
+  }
 
   sdf::PixelFormatType pixelFormat = cameraSdf->PixelFormat();
 

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -228,6 +228,13 @@ bool WideAngleCameraSensor::CreateCamera()
   unsigned int width = cameraSdf->ImageWidth();
   unsigned int height = cameraSdf->ImageHeight();
 
+  if (width == 0u || height == 0u)
+  {
+    gzerr << "Unable to create a wide angle camera sensor with 0 width or "
+          << "height." << std::endl;
+    return false;
+  }
+
   this->dataPtr->camera = this->Scene()->CreateWideAngleCamera(this->Name());
 
   if (!this->dataPtr->camera)


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

Check to verify that camera sensors have non-zero width / height before creating the rendering cameras. The check prevents gz-sim from crashing and will output a more meaningful msg.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

