### PR TITLE
Visualze Frustum

### DIFF
--- a/include/gz/sensors/LogicalCameraSensor.hh
+++ b/include/gz/sensors/LogicalCameraSensor.hh
@@ -104,6 +104,14 @@ namespace gz
       /// \return True if there are subscribers, false otherwise
       public: virtual bool HasConnections() const override;
 
+      /// \brief Check if there are any image subscribers
+      /// \return True if there are image subscribers, false otherwise
+      public: virtual bool HasImageConnections() const;
+
+      /// \brief Check if there are any frustum subscribers
+      /// \return True if there are info subscribers, false otherwise
+      public: virtual bool HasFrustumConnections() const;
+
       /// \brief Get the latest image. An image is an instance of
       /// msgs::LogicalCameraImage, which contains a list of detected models.
       /// \return List of detected models.

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -161,6 +161,10 @@ namespace gz
       /// \return Topic sensor publishes data to
       public: std::string Topic() const;
 
+      /// \brief Get topic where sensor data is published.
+      /// \return Topic sensor publishes data to
+      public: std::string Topic_logic() const;
+
       /// \brief Set topic where sensor data is published.
       /// \param[in] _topic Topic sensor publishes data to.
       /// \return True if a valid topic was set.

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -161,10 +161,6 @@ namespace gz
       /// \return Topic sensor publishes data to
       public: std::string Topic() const;
 
-      /// \brief Get topic where sensor data is published.
-      /// \return Topic sensor publishes data to
-      public: std::string Topic_logic() const;
-
       /// \brief Set topic where sensor data is published.
       /// \param[in] _topic Topic sensor publishes data to.
       /// \return True if a valid topic was set.

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -131,7 +131,8 @@ bool LogicalCameraSensor::Load(sdf::ElementPtr _sdf)
 
   if (!this->dataPtr->pubLogic)
   {
-    gzerr << "Unable to create publisher on topic[" << this->Topic() << "/frustum].\n";
+    gzerr << "Unable to create publisher on topic[" << this->Topic()
+          << "/frustum].\n";
     return false;
   }
 

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -182,7 +182,8 @@ bool LogicalCameraSensor::Update(
   frame->set_key("frame_id");
   frame->add_value(this->FrameId());
 
-  *this->dataPtr->msg_logic.mutable_header()->mutable_stamp() = msgs::Convert(_now);
+  *this->dataPtr->msg_logic.mutable_header()->mutable_stamp() =
+    msgs::Convert(_now);
   this->dataPtr->msg_logic.mutable_header()->clear_data();
   auto frame_log = this->dataPtr->msg_logic.mutable_header()->add_data();
 
@@ -192,8 +193,10 @@ bool LogicalCameraSensor::Update(
   // publish
   this->dataPtr->msg_logic.set_near_clip(this->dataPtr->frustum.Near());
   this->dataPtr->msg_logic.set_far_clip(this->dataPtr->frustum.Far());
-  this->dataPtr->msg_logic.set_horizontal_fov(this->dataPtr->frustum.FOV().Radian());
-  this->dataPtr->msg_logic.set_aspect_ratio(this->dataPtr->frustum.AspectRatio());
+  this->dataPtr->msg_logic.set_horizontal_fov(
+    this->dataPtr->frustum.FOV().Radian());
+  this->dataPtr->msg_logic.set_aspect_ratio(
+    this->dataPtr->frustum.AspectRatio());
   this->AddSequence(this->dataPtr->msg.mutable_header());
 
   this->dataPtr->pub.Publish(this->dataPtr->msg);

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -110,7 +110,7 @@ bool LogicalCameraSensor::Load(sdf::ElementPtr _sdf)
     return false;
 
   if (this->Topic().empty())
-    this->SetTopic("/camera/logical");
+    this->SetTopic("/logical_camera");
 
   this->dataPtr->pub =
       this->dataPtr->node.Advertise<msgs::LogicalCameraImage>(
@@ -236,6 +236,17 @@ msgs::LogicalCameraImage LogicalCameraSensor::Image() const
 //////////////////////////////////////////////////
 bool LogicalCameraSensor::HasConnections() const
 {
-  return this->dataPtr->pub_logic && this->dataPtr->pub_logic.HasConnections();
+  return this->HasImageConnections() || this->HasFrustumConnections();
 }
 
+//////////////////////////////////////////////////
+bool LogicalCameraSensor::HasImageConnections() const
+{
+  return this->dataPtr->pub && this->dataPtr->pub.HasConnections();
+}
+
+//////////////////////////////////////////////////
+bool LogicalCameraSensor::HasFrustumConnections() const
+{
+  return this->dataPtr->pub_logic && this->dataPtr->pub_logic.HasConnections();
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
This PR mainly adds the visualization of Frustum.
We could see it was present in gazebo classic and from gazebo garden onwards the plugin/feature is not available.

## Test it
$ Build gazebo from source.
$ . install/setup.sh
$ gz sim examples/worlds/visualize_frustum.sdf

## Test Ref images,
1. Play the simulation.
![frustum-1](https://github.com/user-attachments/assets/fef2b73b-e838-4d59-aa06-9c725fbef2ba)

2. Select the topic from scroll down.
![frustum-2](https://github.com/user-attachments/assets/df28d6c7-6f7e-4379-b123-8906a5c1809c)

3. Refresh it to get the "logical_camera/frustum" topic.
![frustum-3](https://github.com/user-attachments/assets/ae43d9c8-6c57-43d0-9420-d11c3280d277)

4. Subcriibed to "logical_camera/frustum".
![frustum-4](https://github.com/user-attachments/assets/70cf896e-56f7-4604-993b-a0d11a48fd68)

5. Final output
![frustum-6](https://github.com/user-attachments/assets/83272129-bc1a-4d97-a8c9-d3883d5c1bae)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed
- [ ] All tests passed
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

## Supporting PRs
- https://github.com/gazebosim/gz-sim/pull/2707
- https://github.com/gazebosim/gz-rendering/pull/1095