### PR TITLE
Enable packing w/o padding for PointCloudMsgs

### DIFF
--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -439,14 +439,10 @@ bool DepthCameraSensor::CreateCamera()
         std::placeholders::_4, std::placeholders::_5));
 
   // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured.
   msgs::InitPointCloudPacked(
         this->dataPtr->pointMsg,
         this->OpticalFrameId(),
-        true,
+        false,
         {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
          {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -129,12 +129,7 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
   }
 
   // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured. This same problem is in the
-  // RgbdCameraSensor.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), true,
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), false,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
       {"intensity", msgs::PointCloudPacked::Field::FLOAT32},
       {"ring", msgs::PointCloudPacked::Field::UINT16}});

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -395,12 +395,8 @@ bool RgbdCameraSensor::CreateCameras()
         std::placeholders::_4, std::placeholders::_5));
 
   // Initialize the point message.
-  // \todo(anyone) The true value in the following function call forces
-  // the xyz and rgb fields to be aligned to memory boundaries. This is need
-  // by ROS1: https://github.com/ros/common_msgs/pull/77. Ideally, memory
-  // alignment should be configured.
   msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(),
-      true,
+      false,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
        {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
 

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -431,10 +431,10 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   EXPECT_EQ(static_cast<uint32_t>(vertSamples), pointMsgs.back().height());
   EXPECT_EQ(static_cast<uint32_t>(horzSamples), pointMsgs.back().width());
   EXPECT_FALSE(pointMsgs.back().is_bigendian());
-  EXPECT_EQ(32u, pointMsgs.back().point_step());
-  EXPECT_EQ(32u * horzSamples, pointMsgs.back().row_step());
+  EXPECT_EQ(18u, pointMsgs.back().point_step());
+  EXPECT_EQ(18u * horzSamples, pointMsgs.back().row_step());
   EXPECT_FALSE(pointMsgs.back().is_dense());
-  EXPECT_EQ(32u * horzSamples * vertSamples, pointMsgs.back().data().size());
+  EXPECT_EQ(18u * horzSamples * vertSamples, pointMsgs.back().data().size());
 
   EXPECT_TRUE(pointMsgs.back().has_header());
   EXPECT_LT(1, pointMsgs.back().header().data().size());

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -475,7 +475,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
   {
     // init the point cloud msg to be filled
     msgs::PointCloudPacked pointsMsg;
-    msgs::InitPointCloudPacked(pointsMsg, "depth2Image", true,
+    msgs::InitPointCloudPacked(pointsMsg, "depth2Image", false,
         {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
          {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});
     pointsMsg.set_width(rgbdSensor->ImageWidth());


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
According to comments in code, we have to add a padding for fields in packed points msg for ROS1. And due to current branch is not supporting ROS1, we can switch this padding off to increase throughput.
I checked this change with lidar and rviz and it seems working fine (which I mentioned in comment [here](https://github.com/gazebosim/ros_gz/issues/368#issuecomment-2561744188))

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
