### PR TITLE
Add support for L8 and L16 image formats in WideAngleCameraSensor

### DIFF
--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -333,6 +333,12 @@ bool WideAngleCameraSensor::CreateCamera()
     case sdf::PixelFormatType::RGB_INT8:
       this->dataPtr->camera->SetImageFormat(gz::rendering::PF_R8G8B8);
       break;
+    case sdf::PixelFormatType::L_INT8:
+      this->dataPtr->camera->SetImageFormat(gz::rendering::PF_L8);
+      break;
+    case sdf::PixelFormatType::L_INT16:
+      this->dataPtr->camera->SetImageFormat(gz::rendering::PF_L16);
+      break;
     default:
       gzerr << "Unsupported pixel format ["
         << static_cast<int>(pixelFormat) << "]\n";
@@ -367,8 +373,10 @@ void WideAngleCameraSensor::OnNewWideAngleFrame(
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
-  unsigned int len = _width * _height * _channels;
-  unsigned int bufferSize = len * sizeof(unsigned char);
+  unsigned int bytesPerChannel = rendering::PixelUtil::BytesPerChannel(
+      this->dataPtr->camera->ImageFormat());
+  unsigned int len = _width * _height * _channels * bytesPerChannel;
+  unsigned int bufferSize = len * sizeof(unsigned char) ;
 
   if (!this->dataPtr->imageBuffer)
     this->dataPtr->imageBuffer = new unsigned char[len];
@@ -466,6 +474,12 @@ bool WideAngleCameraSensor::Update(
     case gz::rendering::PF_R8G8B8:
       format = gz::common::Image::RGB_INT8;
       msgsPixelFormat = msgs::PixelFormatType::RGB_INT8;
+      break;
+    case gz::rendering::PF_L8:
+      msgsPixelFormat = msgs::PixelFormatType::L_INT8;
+      break;
+    case gz::rendering::PF_L16:
+      msgsPixelFormat = msgs::PixelFormatType::L_INT16;
       break;
     default:
       gzerr << "Unsupported pixel format ["

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -376,7 +376,7 @@ void WideAngleCameraSensor::OnNewWideAngleFrame(
   unsigned int bytesPerChannel = rendering::PixelUtil::BytesPerChannel(
       this->dataPtr->camera->ImageFormat());
   unsigned int len = _width * _height * _channels * bytesPerChannel;
-  unsigned int bufferSize = len * sizeof(unsigned char) ;
+  unsigned int bufferSize = len * sizeof(unsigned char);
 
   if (!this->dataPtr->imageBuffer)
     this->dataPtr->imageBuffer = new unsigned char[len];


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gz-sensors/issues/479

Related PR: https://github.com/gazebosim/gz-rendering/pull/1097

## Summary

Added L8 and L16 type support. 

## Test it

You'll first need https://github.com/gazebosim/gz-rendering/pull/1097

Then edit [wide_angle_camera.sdf](https://github.com/gazebosim/gz-sim/blob/d83d1352600022ea9da20906000a963580c7f258/examples/worlds/wide_angle_camera.sdf#L308) world in gz-sim, and add `<format>L8</format>` to the `//model/link/sensor/camera/image` tag, e.g.

```diff
diff --git a/examples/worlds/wide_angle_camera.sdf b/examples/worlds/wide_angle_camera.sdf
index 8482ae695..ce9c49c45 100644
--- a/examples/worlds/wide_angle_camera.sdf
+++ b/examples/worlds/wide_angle_camera.sdf
@@ -306,6 +306,7 @@
             <image>
               <width>800</width>
               <height>600</height>
+              <format>L8</format>
             </image>
             <clip>
               <near>0.1</near>
```

Run the example world to see the wide angle camera image in gray:

<img width="629" alt="wideanglecam_L8" src="https://github.com/user-attachments/assets/291c91ba-ca6b-47bc-8649-03ca004019d4" />



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

