### PR TITLE
Fix airspeed calculation under wind influence by wind triangle

### DIFF
--- a/include/gz/sensors/AirSpeedSensor.hh
+++ b/include/gz/sensors/AirSpeedSensor.hh
@@ -71,6 +71,9 @@ namespace gz
       /// \brief Update the velocity of the sensor
       public: void SetVelocity(const gz::math::Vector3d &_vel);
 
+      /// \brief Update the wind velocity
+      public: void SetWindVelocity(const gz::math::Vector3d &_windVel);
+
       using Sensor::Update;
 
       /// \brief Update the sensor and generate data

--- a/src/AirSpeedSensor.cc
+++ b/src/AirSpeedSensor.cc
@@ -68,6 +68,9 @@ class gz::sensors::AirSpeedSensorPrivate
   /// \brief Velocity of the air coming from the sensor
   public: gz::math::Vector3d vel;
 
+  /// \brief Velocity of the wind coming from the sensor
+  public: gz::math::Vector3d windVel;
+
   /// \brief Noise added to sensor data
   public: std::map<SensorNoiseType, NoisePtr> noises;
 };
@@ -169,12 +172,10 @@ bool AirSpeedSensor::Update(
   const float density_ratio = powf(kTemperaturMsl / temperature_local , 4.256f);
   const float air_density = kAirDensityMsl / density_ratio;
 
-  math::Vector3d wind_vel_{0, 0, 0};
   math::Quaterniond veh_q_world_to_body = this->Pose().Rot();
-
   // calculate differential pressure + noise in hPa
   math::Vector3d air_vel_in_body_ = this->dataPtr->vel -
-    veh_q_world_to_body.RotateVectorReverse(wind_vel_);
+    veh_q_world_to_body.RotateVectorReverse(this->dataPtr->windVel);
   float diff_pressure = math::sgn(air_vel_in_body_.X()) * 0.005f * air_density
     * air_vel_in_body_.X() * air_vel_in_body_.X();
 
@@ -207,6 +208,12 @@ gz::math::Vector3d AirSpeedSensor::Velocity() const
 void AirSpeedSensor::SetVelocity(const gz::math::Vector3d &_vel)
 {
   this->dataPtr->vel = _vel;
+}
+
+//////////////////////////////////////////////////
+void AirSpeedSensor::SetWindVelocity(const gz::math::Vector3d &_windVel)
+{
+  this->dataPtr->windVel = _windVel;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Result from the discussion in https://github.com/PX4/PX4-Autopilot/pull/24452

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Add a new function `SetWindVelocity()` to receive the wind information from the airspeed sensor plugin in gz-sim

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

