### PR TITLE
ci.yml: use noble, disable jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
-          codecov-enabled: true
+          # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,6 @@ on:
       - 'main'
 
 jobs:
-  jammy-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Jammy CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@jammy
-        with:
-          codecov-enabled: true
-          cppcheck-enabled: true
-          cpplint-enabled: true
-          doxygen-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -33,5 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true
+          doxygen-enabled: true

--- a/tutorials/boundingbox_camera.md
+++ b/tutorials/boundingbox_camera.md
@@ -241,7 +241,7 @@ gz sim boundingbox_camera.sdf
 
 you will find that the dataset is saved in the given path
 
-#### Dataset Demo
+### Dataset Demo
 
 ![dataset_generation](files/boundingbox_camera/object_detection_dataset.gif)
 

--- a/tutorials/segmentation_camera.md
+++ b/tutorials/segmentation_camera.md
@@ -96,7 +96,7 @@ As we can see, we define a sensor with the following SDF elements:
 * `<visualize>`: Whether the sensor should be visualized in the GUI (indicated by true) or not (indicated by false). This is currently unused by Gazebo.
 * `<topic>`: The name of the topic which will be used to publish the sensor data.
 
-#### Label map & Colored map
+### Label map & Colored map
 The segmentation sensor creates 2 maps (or images):
 
 - The `label map`: For semantic segmentation, each pixel contains the object's label. For panoptic segmentation, each pixel contains the label and object's instance count.
@@ -271,7 +271,7 @@ To save the output of the sensor as segmentation dataset samples, we add the `<s
 In the example world we just ran (`segmentation_camera.sdf`), you'll notice that the panoptic camera is saving data to `segmentation_data/instance_camera`, while the semenatic camera is saving data to
 `segmentation_data/semantic_camera` (these are relative paths).
 
-#### Dataset Demo
+### Dataset Demo
 
 Up to this point, we have left simulation paused.
 Go ahead and start simulation by pressing the play button at the bottom-left part of the GUI.


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebo-tooling/release-tools/issues/1222, split out from https://github.com/gazebosim/gz-sensors/pull/515

## Summary

Jammy isn't officially supported for Jetty, so disable it and move special checks to use Noble.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
