### PR TITLE
Update CameraSensor.ccAllow HFOV narrower than 0.5°

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -196,7 +196,7 @@ bool CameraSensor::CreateCamera()
   this->dataPtr->camera->SetAntiAliasing(cameraSdf->AntiAliasingValue());
 
   math::Angle angle = cameraSdf->HorizontalFov();
-  if (angle < 0.01 || angle > GZ_PI*2)
+  if (angle < 0.001 || angle > GZ_PI*2)
   {
     gzerr << "Invalid horizontal field of view [" << angle << "]\n";
 


### PR DESCRIPTION
# 🎉 New feature

Closes #518

## Summary
Allows camera sensor HFOV as narrow as 0.5°, and even bellow.

## Test it
Create a camera sensor which an HFOV of 0.5° (~0.0087 rad) and launch a simulation

Corresponding PR in `sdformat` : https://github.com/gazebosim/sdformat/pull/1563

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
