### PR TITLE
Clarify min and max temperature of thermal camera

### DIFF
--- a/tutorials/thermal_camera.md
+++ b/tutorials/thermal_camera.md
@@ -114,13 +114,20 @@ As we can see, we define a sensor with the following SDF elements:
 
 There's also an optional plugin used here that allows for further configuration of the thermal camera.
 Here's a description of the elements in this plugin (if the plugin isn't used, the default values mentioned below are used):
-* `<min_temp>`: The thermal camera's minimum temperature, in Kelvin.
-                The default minimum temperature is `0`.
-* `<max_temp>`: The thermal camera's maximum temperature, in Kelvin.
-                The default maximum temperature is calculated as `(2^(bitDepth) - 1) * resolution`.
-                For a 8-bit thermal camera with a linear resolution of `3.0`, the maximum temperature is `((2^8) - 1) * 3 = 765 Kelvin`.
 * `<resolution>`: The thermal camera's linear resolution.
+                  This defines the mapping of temperatures onto image values.
+                  A temperature of `x` Kelvin corresponds to an image value of `x * resolution`.
+                  Note that this implies an implicit minimum temperature of `0` Kelvin and an implicit maximum temperature of `(2^bitDepth - 1) * resolution` Kelvin due to the limited range of image values.
+                  For example, for an 8-bit thermal camera with a linear resolution of `3.0`, the implicit maximum temperature is `((2^8) - 1) * 3 = 765 Kelvin`.
                   The default linear resolution is `0.01` for a 16-bit thermal camera, and `3.0` for a 8-bit thermal camera.
+* `<min_temp>`: The thermal camera's additional minimum temperature, in Kelvin.
+                By default, there is no additional lower bound.
+* `<max_temp>`: The thermal camera's additional maximum temperature, in Kelvin.
+                By default, there is no additional upper bound.
+
+Note that the elements `<min_temp>` and `<max_temp>` do not influence the mapping between image values and temperatures.
+Instead, they are only used for clamping down the camera output:
+Any temperature lower than `<min_temp>` will be output by the camera as if it was *exactly equal* to `<min_temp>` (and symmetrically for `<max_temp>`).
 
 ## Assigning a temperature to a model
 


### PR DESCRIPTION
This is an attempt to improve the documentation of the `<min_temp>`, `<max_temp>` and `<resolution>` tags in the thermal camera documentation.

After reading the description of `<min_temp>` and `<max_temp>` in the thermal camera tutorial I expected an output camera image value of `0` to mean `<min_temp>` Kelvin and a value of `2^bitDepth - 1` to mean `<max_temp>` Kelvin, so I was surprised to find out that that was not the case. Granted, the presence of the `<resolution>` tag did not really fit this mental model. It is also possible that this confusion was amplified by bugs that are now fixed (https://github.com/gazebosim/gz-rendering/pull/1133 and https://github.com/gazebosim/gz-rendering/pull/1138).

Nevertheless I tried to rephrase the descriptions a bit in an attempt to minimize the potential for confusion in the future. Hopefully it makes some sense to people other than me.

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.