### PR TITLE
Update API to return const references to strings

### DIFF
--- a/include/gz/sensors/CameraSensor.hh
+++ b/include/gz/sensors/CameraSensor.hh
@@ -122,7 +122,7 @@ namespace gz
 
       /// \brief Topic where camera info is published.
       /// \return Camera info topic.
-      public: std::string InfoTopic() const;
+      public: const std::string& InfoTopic() const;
 
       /// \brief Set baseline for stereo cameras. This is used to populate the
       /// projection matrix in the camera info message.

--- a/include/gz/sensors/Sensor.hh
+++ b/include/gz/sensors/Sensor.hh
@@ -147,11 +147,11 @@ namespace gz
 
       /// \brief Get name.
       /// \return Name of sensor.
-      public: std::string Name() const;
+      public: const std::string& Name() const;
 
       /// \brief FrameId.
       /// \return FrameId of sensor.
-      public: std::string FrameId() const;
+      public: const std::string& FrameId() const;
 
       /// \brief Set Frame ID of the sensor
       /// \param[in] _frameId Frame ID of the sensor
@@ -159,7 +159,7 @@ namespace gz
 
       /// \brief Get topic where sensor data is published.
       /// \return Topic sensor publishes data to
-      public: std::string Topic() const;
+      public: const std::string& Topic() const;
 
       /// \brief Set topic where sensor data is published.
       /// \param[in] _topic Topic sensor publishes data to.
@@ -176,7 +176,7 @@ namespace gz
 
       /// \brief Get parent link of the sensor.
       /// \return Parent link of sensor.
-      public: std::string Parent() const;
+      public: const std::string& Parent() const;
 
       /// \brief Get the sensor's ID.
       /// \return The sensor's ID.

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -592,7 +592,7 @@ rendering::CameraPtr CameraSensor::RenderingCamera() const
 }
 
 //////////////////////////////////////////////////
-std::string CameraSensor::InfoTopic() const
+const std::string& CameraSensor::InfoTopic() const
 {
   return this->dataPtr->infoTopic;
 }

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -282,13 +282,13 @@ SensorId Sensor::Id() const
 }
 
 //////////////////////////////////////////////////
-std::string Sensor::Name() const
+const std::string& Sensor::Name() const
 {
   return this->dataPtr->name;
 }
 
 //////////////////////////////////////////////////
-std::string Sensor::FrameId() const
+const std::string& Sensor::FrameId() const
 {
   return this->dataPtr->frameId;
 }
@@ -300,7 +300,7 @@ void Sensor::SetFrameId(const std::string &_frameId)
 }
 
 //////////////////////////////////////////////////
-std::string Sensor::Topic() const
+const std::string& Sensor::Topic() const
 {
   return this->dataPtr->topic;
 }
@@ -441,7 +441,7 @@ gz::math::Pose3d Sensor::Pose() const
 }
 
 //////////////////////////////////////////////////
-std::string Sensor::Parent() const
+const std::string& Sensor::Parent() const
 {
   return this->dataPtr->parent;
 }


### PR DESCRIPTION
# 🎉 New feature

Follow up to #525 

## Summary

While fixing an issue with #525, I noticed several APIs that return `std::string` when it would be advantageous for them to return `const std::string &` instead, and easy since they already return a copy of member variable, which will now return a reference.

Changes the following methods:

* CameraSensor::InfoTopic()
* Sensor::Name()
* Sensor::FrameId()
* Sensor::Parent()
* Sensor::Topic()


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
