### PR TITLE
Disable ign-sensors6's (fortress) failing tests on Windows

### DIFF
--- a/test/integration/boundingbox_camera.cc
+++ b/test/integration/boundingbox_camera.cc
@@ -29,6 +29,8 @@
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/BoundingBoxCamera.hh>
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -479,13 +481,15 @@ void BoundingBoxCameraSensorTest::Boxes3DWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(BoundingBoxCameraSensorTest, BoxesWithBuiltinSDF)
+TEST_P(BoundingBoxCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(BoxesWithBuiltinSDF))
 {
   BoxesWithBuiltinSDF(GetParam());
 }
 
 //////////////////////////////////////////////////
-TEST_P(BoundingBoxCameraSensorTest, Boxes3DWithBuiltinSDF)
+TEST_P(BoundingBoxCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(Boxes3DWithBuiltinSDF))
 {
   Boxes3DWithBuiltinSDF(GetParam());
 }

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -47,6 +47,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -183,7 +185,8 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, ImagesWithBuiltinSDF)
+TEST_P(CameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }
@@ -479,7 +482,8 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, CameraIntrinsics)
+TEST_P(CameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(CameraIntrinsics))
 {
   gz::common::Console::SetVerbosity(2);
   CameraIntrinsics(GetParam());
@@ -778,7 +782,8 @@ void CameraSensorTest::CameraProjection(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, CameraProjection)
+TEST_P(CameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(CameraProjection))
 {
   gz::common::Console::SetVerbosity(2);
   CameraProjection(GetParam());
@@ -871,7 +876,8 @@ void CameraSensorTest::ImageFormatLInt8(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, LInt8ImagesWithBuiltinSDF)
+TEST_P(CameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LInt8ImagesWithBuiltinSDF))
 {
   ImageFormatLInt8(GetParam());
 }
@@ -963,7 +969,8 @@ void CameraSensorTest::ImageFormatLInt16(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(CameraSensorTest, LInt16ImagesWithBuiltinSDF)
+TEST_P(CameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(LInt16ImagesWithBuiltinSDF))
 {
   ImageFormatLInt16(GetParam());
 }

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -48,6 +48,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -503,7 +505,8 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(DepthCameraSensorTest, ImagesWithBuiltinSDF)
+TEST_P(DepthCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -50,6 +50,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include <sdf/sdf.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
@@ -942,57 +944,43 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(GpuLidarSensorTest, DISABLED_CreateGpuLidar)
-#else
-TEST_P(GpuLidarSensorTest, CreateGpuLidar)
-#endif
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(CreateGpuLidar))
 {
   CreateGpuLidar(GetParam());
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(GpuLidarSensorTest, DISABLED_DetectBox)
-#else
-TEST_P(GpuLidarSensorTest, DetectBox)
-#endif
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(DetectBox))
 {
   DetectBox(GetParam());
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(GpuLidarSensorTest, DISABLED_TestThreeBoxes)
-#else
-TEST_P(GpuLidarSensorTest, TestThreeBoxes)
-#endif
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TestThreeBoxes))
 {
   TestThreeBoxes(GetParam());
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(GpuLidarSensorTest, DISABLED_VerticalLidar)
-#else
-TEST_P(GpuLidarSensorTest, VerticalLidar)
-#endif
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(VerticalLidar))
 {
   VerticalLidar(GetParam());
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(GpuLidarSensorTest, DISABLED_ManualUpdate)
-#else
-TEST_P(GpuLidarSensorTest, ManualUpdate)
-#endif
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ManualUpdate))
 {
   ManualUpdate(GetParam());
 }
 
 /////////////////////////////////////////////////
-TEST_P(GpuLidarSensorTest, Topic)
+TEST_P(GpuLidarSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(Topic))
 {
   Topic(GetParam());
 }

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -48,6 +48,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -748,7 +750,8 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(RgbdCameraSensorTest, ImagesWithBuiltinSDF)
+TEST_P(RgbdCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }

--- a/test/integration/segmentation_camera.cc
+++ b/test/integration/segmentation_camera.cc
@@ -43,6 +43,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -362,7 +364,8 @@ void SegmentationCameraSensorTest::ImagesWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(SegmentationCameraSensorTest, ImagesWithBuiltinSDF)
+TEST_P(SegmentationCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -360,7 +360,7 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
 //////////////////////////////////////////////////
 // See: https://github.com/gazebosim/gz-rendering/issues/654
 TEST_P(ThermalCameraSensorTest,
-       IGN_UTILS_TEST_DISABLED_ON_MAC(ImagesWithBuiltinSDF))
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }
@@ -620,7 +620,8 @@ void ThermalCameraSensorTest::Images8BitWithBuiltinSDF(
 }
 
 //////////////////////////////////////////////////
-TEST_P(ThermalCameraSensorTest, Images8BitWithBuiltinSDF)
+TEST_P(ThermalCameraSensorTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(Images8BitWithBuiltinSDF))
 {
   Images8BitWithBuiltinSDF(GetParam());
 }

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -45,6 +45,8 @@
 #pragma warning(pop)
 #endif
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
 
@@ -153,7 +155,8 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 }
 
 //////////////////////////////////////////////////
-TEST_P(TriggeredCameraTest, ImagesWithBuiltinSDF)
+TEST_P(TriggeredCameraTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ImagesWithBuiltinSDF))
 {
   ImagesWithBuiltinSDF(GetParam());
 }


### PR DESCRIPTION
# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gz-sensors/issues/503

## Summary

Disables tests on Windows to reduce noise in CI

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

