### PR TITLE
Better GZ_PROFILE instrumentation for rendering sensors

### DIFF
--- a/examples/loop_sensor/main.cc
+++ b/examples/loop_sensor/main.cc
@@ -72,7 +72,7 @@ int main(int argc,  char **argv)
       {
         auto sensor = link->SensorByIndex(s);
 
-        gz::sensors::Sensor *sensorPtr;
+        gz::sensors::Sensor *sensorPtr{};
         if (sensor->Type() == sdf::SensorType::ALTIMETER)
         {
           sensorPtr = mgr.CreateSensor<gz::sensors::AltimeterSensor>(

--- a/include/gz/sensors/Manager.hh
+++ b/include/gz/sensors/Manager.hh
@@ -17,11 +17,10 @@
 #ifndef GZ_SENSORS_MANAGER_HH_
 #define GZ_SENSORS_MANAGER_HH_
 
+#include <chrono>
 #include <memory>
-#include <string>
 #include <utility>
 #include <type_traits>
-#include <vector>
 #include <sdf/sdf.hh>
 #include <gz/utils/SuppressWarning.hh>
 #include <gz/common/Console.hh>
@@ -42,7 +41,7 @@ namespace gz
     /// \brief Loads and runs sensors
     ///
     ///   This class is responsible for loading and running sensors, and
-    ///   providing sensors with common environments to generat data from.
+    ///   providing sensors with common environments to generate data from.
     ///
     ///   The primary interface through which to load a sensor is LoadSensor().
     ///   This takes an sdf element pointer that should be configured with
@@ -62,7 +61,7 @@ namespace gz
       /// \return True if successfully initialized, false if not
       public: bool Init();
 
-      /// \brief Create a sensor from an SDF ovject with a known sensor type.
+      /// \brief Create a sensor from an SDF object with a known sensor type.
       /// \sa Sensor()
       /// \param[in] _sdf An SDF element or DOM object.
       /// \tparam SensorType Sensor type

--- a/src/BoundingBoxCameraSensor.cc
+++ b/src/BoundingBoxCameraSensor.cc
@@ -393,10 +393,9 @@ rendering::BoundingBoxCameraPtr
 void BoundingBoxCameraSensor::OnNewBoundingBoxes(
   const std::vector<rendering::BoundingBox> &_boxes)
 {
+  GZ_PROFILE("BoundingBoxCameraSensor::OnNewBoundingBoxes");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  this->dataPtr->boundingBoxes.clear();
-  for (const auto &box : _boxes)
-    this->dataPtr->boundingBoxes.push_back(box);
+  this->dataPtr->boundingBoxes = _boxes;
 }
 
 //////////////////////////////////////////////////

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/camera_info.pb.h>
 #include <gz/msgs/image.pb.h>
 
@@ -428,8 +427,8 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
   {
     if (this->dataPtr->generatingData)
     {
-      gzdbg << "Disabling camera sensor: '" << this->Name() << "' data "
-             << "generation. " << std::endl;;
+      gzdbg << "Disabling camera sensor: '" << this->Name()
+            << "' data generation. " << std::endl;
       this->dataPtr->generatingData = false;
     }
 
@@ -439,8 +438,8 @@ bool CameraSensor::Update(const std::chrono::steady_clock::duration &_now)
   {
     if (!this->dataPtr->generatingData)
     {
-      gzdbg << "Enabling camera sensor: '" << this->Name() << "' data "
-             << "generation." << std::endl;;
+      gzdbg << "Enabling camera sensor: '" << this->Name()
+            << "' data generation." << std::endl;
       this->dataPtr->generatingData = true;
     }
   }

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -461,6 +461,7 @@ void DepthCameraSensor::OnNewDepthFrame(const float *_scan,
                     unsigned int /*_channels*/,
                     const std::string &_format)
 {
+  GZ_PROFILE("DepthCameraSensor::OnNewDepthFrame");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   unsigned int depthSamples = _width * _height;
@@ -488,6 +489,7 @@ void DepthCameraSensor::OnNewRgbPointCloud(const float *_scan,
                     unsigned int _channels,
                     const std::string &/*_format*/)
 {
+  GZ_PROFILE("DepthCameraSensor::OnNewRgbPointCloud");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   unsigned int pointCloudSamples = _width * _height;
@@ -595,10 +597,12 @@ bool DepthCameraSensor::Update(
   msg.set_data(this->dataPtr->depthBuffer,
       rendering::PixelUtil::MemorySize(rendering::PF_FLOAT32_R,
       width, height));
-
   this->AddSequence(msg.mutable_header(), "default");
-  this->dataPtr->pub.Publish(msg);
 
+  {
+    GZ_PROFILE("DepthCameraSensor::Update Publish");
+    this->dataPtr->pub.Publish(msg);
+  }
 
   if (this->dataPtr->imageEvent.ConnectionCount() > 0u)
   {

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -236,6 +236,7 @@ void GpuLidarSensor::OnNewLidarFrame(const float *_scan,
     unsigned int _width, unsigned int _height, unsigned int _channels,
     const std::string &_format)
 {
+  GZ_PROFILE("GpuLidarSensor::OnNewLidarFrame");
   std::lock_guard<std::mutex> lock(this->lidarMutex);
 
   unsigned int samples = _width * _height * _channels;

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -508,7 +508,7 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
 }
 
 sdf::ElementPtr sensorWithLocalization(
-  std::string _orientationLocalization)
+  const std::string &_orientationLocalization)
 {
   std::ostringstream stream;
   stream

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -194,7 +194,6 @@ bool LogicalCameraSensor::Update(
   frame_log->set_key("frame_id");
   frame_log->add_value(this->FrameId());
 
-  // publish
   this->dataPtr->msgLogic.set_near_clip(this->dataPtr->frustum.Near());
   this->dataPtr->msgLogic.set_far_clip(this->dataPtr->frustum.Far());
   this->dataPtr->msgLogic.set_horizontal_fov(
@@ -203,8 +202,12 @@ bool LogicalCameraSensor::Update(
     this->dataPtr->frustum.AspectRatio());
   this->AddSequence(this->dataPtr->msg.mutable_header());
 
-  this->dataPtr->pub.Publish(this->dataPtr->msg);
-  this->dataPtr->pubLogic.Publish(this->dataPtr->msgLogic);
+  // publish
+  {
+    GZ_PROFILE("LogicalCameraSensor::Update Publish");
+    this->dataPtr->pub.Publish(this->dataPtr->msg);
+    this->dataPtr->pubLogic.Publish(this->dataPtr->msgLogic);
+  }
 
   return true;
 }

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -431,6 +431,7 @@ void RgbdCameraSensorPrivate::OnNewDepthFrame(const float *_scan,
                     unsigned int /*_channels*/,
                     const std::string &/*_format*/)
 {
+  GZ_PROFILE("RgbdCameraSensorPrivate::OnNewDepthFrame");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   unsigned int depthSamples = _width * _height;
@@ -448,6 +449,7 @@ void RgbdCameraSensorPrivate::OnNewRgbPointCloud(const float *_scan,
                     unsigned int _channels,
                     const std::string &/*_format*/)
 {
+  GZ_PROFILE("RgbdCameraSensorPrivate::OnNewRgbPointCloud");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   unsigned int pointCloudSamples = _width * _height;
@@ -513,7 +515,7 @@ bool RgbdCameraSensor::Update(const std::chrono::steady_clock::duration &_now)
   // generate sensor data
   this->Render();
 
-  // create and publish the depthmessage
+  // create and publish the depth message
   if (this->HasDepthConnections())
   {
     msgs::Image msg;

--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -434,6 +434,7 @@ void SegmentationCameraSensor::OnNewSegmentationFrame(const uint8_t * _data,
   unsigned int _width, unsigned int _height, unsigned int _channels,
   const std::string &/*_format*/)
 {
+  GZ_PROFILE("SegmentationCameraSensor::OnNewSegmentationFrame");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   unsigned int bufferSize = _width * _height * _channels;
@@ -539,8 +540,11 @@ bool SegmentationCameraSensor::Update(
       width, height));
 
   // Publish
-  this->dataPtr->coloredMapPublisher.Publish(this->dataPtr->coloredMapMsg);
-  this->dataPtr->labelsMapPublisher.Publish(this->dataPtr->labelsMapMsg);
+  {
+    GZ_PROFILE("SegmentationCameraSensor::Update Publish");
+    this->dataPtr->coloredMapPublisher.Publish(this->dataPtr->coloredMapMsg);
+    this->dataPtr->labelsMapPublisher.Publish(this->dataPtr->labelsMapMsg);
+  }
 
   // Trigger callbacks.
   if (this->dataPtr->imageEvent.ConnectionCount() > 0u)

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -379,6 +379,7 @@ void ThermalCameraSensor::OnNewThermalFrame(const uint16_t *_scan,
                     unsigned int /*_channels*/,
                     const std::string &/*_format*/)
 {
+  GZ_PROFILE("ThermalCameraSensor::OnNewThermalFrame");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   unsigned int samples = _width * _height;
@@ -505,8 +506,10 @@ bool ThermalCameraSensor::Update(
         width, height));
   }
 
-
-  this->dataPtr->thermalPub.Publish(this->dataPtr->thermalMsg);
+  {
+    GZ_PROFILE("ThermalCameraSensor::Update Publish");
+    this->dataPtr->thermalPub.Publish(this->dataPtr->thermalMsg);
+  }
 
   // Trigger callbacks.
   try

--- a/src/WideAngleCameraSensor.cc
+++ b/src/WideAngleCameraSensor.cc
@@ -371,6 +371,7 @@ void WideAngleCameraSensor::OnNewWideAngleFrame(
     unsigned int _channels,
     const std::string &/*_format*/)
 {
+  GZ_PROFILE("WideAngleCameraSensor::OnNewWideAngleFrame");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   unsigned int bytesPerChannel = rendering::PixelUtil::BytesPerChannel(
@@ -436,8 +437,8 @@ bool WideAngleCameraSensor::Update(
   {
     if (this->dataPtr->generatingData)
     {
-      gzdbg << "Disabling camera sensor: '" << this->Name() << "' data "
-             << "generation. " << std::endl;;
+      gzdbg << "Disabling camera sensor: '" << this->Name()
+            << "' data  generation. " << std::endl;
       this->dataPtr->generatingData = false;
     }
 
@@ -447,8 +448,8 @@ bool WideAngleCameraSensor::Update(
   {
     if (!this->dataPtr->generatingData)
     {
-      gzdbg << "Enabling camera sensor: '" << this->Name() << "' data "
-             << "generation." << std::endl;;
+      gzdbg << "Enabling camera sensor: '" << this->Name()
+            << "' data generation." << std::endl;
       this->dataPtr->generatingData = true;
     }
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Renderings sensors is a very powerful but also very controversial in terms of performance tool. In this patch I'd like to align profiler tooling for this type of sensors (some sensors already have desired instrumentation).
Now we can see callback execution time (copying is not free as expected) and publishing data (which is also some kind of copying).
And everything in between is a data conversion. I have some idea how to improve rtf, but it should be discussed first.

Also fixed some problems which came across (like to make CppCheck happy or similar)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.