### PR TITLE
Fix flaky test in DepthCameraSensorTest::ImagesWithBuiltinSDF

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -449,7 +449,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   EXPECT_GT(counter, 0);
   EXPECT_GT(pcCounter, 0);
   EXPECT_EQ(counter, infoCounter);
-  EXPECT_EQ(counter, pcCounter);
+  EXPECT_LE(std::abs(counter - pcCounter), 1); 
   counter = 0;
   infoCounter = 0;
   pcCounter = 0;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #510 

## Summary
The test occasionally fails because the point cloud message count `pcCounter` can be off by one compared to the image message count `counter`, due to asynchronous message delivery and race conditions between message arrival and counter reset.

This PR relaxes the assertion to allow a difference of 1 between the counters, which does not affect the correctness of the test, but makes it robust against timing issues.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
