### PR TITLE
[Bazel] Fix downstream build errors with -Werror

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -242,8 +242,8 @@ gz_sensor_library(
     name = "depth_camera",
     srcs = ["src/DepthCameraSensor.cc"],
     hdrs = ["include/gz/sensors/DepthCameraSensor.hh"],
-    copts = [
-        "-Wno-private-header",  # Needs private headers from :gz-sensors and :camera
+    features = [
+        "-layering_check",  # Needs private headers from :gz-sensors and :camera
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],
@@ -482,8 +482,8 @@ gz_sensor_library(
         "src/RgbdCameraSensor.cc",
     ],
     hdrs = ["include/gz/sensors/RgbdCameraSensor.hh"],
-    copts = [
-        "-Wno-private-header",  # Needs private headers from :gz-sensors and :camera
+    features = [
+        "-layering_check",  # Needs private headers from :gz-sensors and :camera
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes downstream build errors when compiling depending targets with `--copt=-Werror`. The error comes from a few private headers being included in `:depth_camera` and `:rgbd_camera`. Although I added `--copt=-Wno-private-header` to downgrade errors to warning, those targets still fail to build with `--copt=-Werror`. So the better fix here is to disable layering check for those two targets.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
