### PR TITLE
Add missing includes

### DIFF
--- a/test/integration/dvl.cc
+++ b/test/integration/dvl.cc
@@ -25,6 +25,7 @@
 
 #include <gz/msgs/dvl_velocity_tracking.pb.h>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/rendering/Material.hh>
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>

--- a/test/integration/force_torque.cc
+++ b/test/integration/force_torque.cc
@@ -24,6 +24,7 @@
 
 #include <gz/msgs/wrench.pb.h>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/sensors/ForceTorqueSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/imu.cc
+++ b/test/integration/imu.cc
@@ -21,6 +21,7 @@
 
 #include <gz/msgs/imu.pb.h>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/sensors/ImuSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/magnetometer.cc
+++ b/test/integration/magnetometer.cc
@@ -21,6 +21,7 @@
 
 #include <gz/msgs/magnetometer.pb.h>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/sensors/MagnetometerSensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -21,6 +21,7 @@
 #include <gz/msgs/camera_info.pb.h>
 #include <gz/msgs/image.pb.h>
 
+#include <gz/msgs/Utility.hh>
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Event.hh>
 #include <gz/sensors/Manager.hh>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Upcoming changes in gz-transport(https://github.com/gazebosim/gz-transport/pull/665) cause build failures because the `gz/msgs/Utility.hh` wasn't included in some test.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
