### PR TITLE
Update boundingbox_camera.md with the proper projection matrix

### DIFF
--- a/tutorials/boundingbox_camera.md
+++ b/tutorials/boundingbox_camera.md
@@ -369,15 +369,15 @@ def euler_to_rotation(theta) :
 """
 This matrix are specific for the camera configuration in the SDF world
 
-    <horizontal_fov>1.57</horizontal_fov>
+    <horizontal_fov>1.047</horizontal_fov>
     <width>800</width>
     <height>600</height>
 
 If any of them is changed, you have to change the projection matrix
 """
 projMatrix = np.array([
-    [0.99975, 0, 0, 0],
-    [0, 1.333, 0, 0 ],
+    [1.732, 0, 0, 0],
+    [0, 2.309, 0, 0 ],
     [0, 0, -1.00002, -0.02],
     [0, 0, -1, 0]
 ])


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The projection matrix assumed a horizontal fov of 1.57, when all of the rest of the example uses a horizontal fov of 1.047. This matches the projection matrix to the rest of the example so the python code works correctly without modification.

Before: 
<img width="800" height="600" alt="image3d" src="https://github.com/user-attachments/assets/3865161e-1306-4b0e-a717-e7c758ba1921" />

After:
<img width="800" height="600" alt="image3d_corrected" src="https://github.com/user-attachments/assets/df095383-2e16-4e70-bc4e-e83a834d793a" />

This is just an update to a tutorial, so testing was done primarily by following the tutorial. 

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.