### PR TITLE
Fix: updated jacobi as template

### DIFF
--- a/src/DopplerVelocityLog.cc
+++ b/src/DopplerVelocityLog.cc
@@ -1573,9 +1573,9 @@ namespace gz
         // Enough rows for a unique least squares solution
         const Eigen::MatrixXd svdMat =
           beamBasis.topRows(numBeamsLocked).eval();
-        using SvdT = Eigen::JacobiSVD<Eigen::MatrixXd,
-            Eigen::ComputeThinU | Eigen::ComputeThinV>;
-        const SvdT svdDecomposition(svdMat);
+        using SvdT = Eigen::JacobiSVD<Eigen::MatrixXd>;
+        const SvdT svdDecomposition(svdMat,
+          Eigen::ComputeThinU | Eigen::ComputeThinV);
 
         // Estimate DVL velocity mean and covariance in the reference frame
         const Eigen::Vector3d velocityMeanInReferenceFrame =
@@ -1825,9 +1825,9 @@ namespace gz
         // Enough rows for a unique least squares solution
         const Eigen::MatrixXd svdMat =
           beamBasis.topRows(numBeamsLocked).eval();
-        using SvdT = Eigen::JacobiSVD<Eigen::MatrixXd,
-            Eigen::ComputeThinU | Eigen::ComputeThinV>;
-        const SvdT svdDecomposition(svdMat);
+        using SvdT = Eigen::JacobiSVD<Eigen::MatrixXd>;
+        const SvdT svdDecomposition(svdMat,
+          Eigen::ComputeThinU | Eigen::ComputeThinV);
 
         // Estimate DVL velocity mean and covariance in the reference frame
         const Eigen::Vector3d velocityMeanInReferenceFrame =


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #559 

## Summary
Replicate warning:
1. Go to https://build.osrfoundation.org/job/gz_sensors-ci-gz-sensors10-homebrew-amd64 before the merge
2. Build the job
3. See the warning appear

Changes made

```diff
-        const auto svdDecomposition =
-            beamBasis.topRows(numBeamsLocked).jacobiSvd(
-                Eigen::ComputeThinU | Eigen::ComputeThinV);

+        const Eigen::MatrixXd svdMat =
+          beamBasis.topRows(numBeamsLocked).eval();
+        using SvdT = Eigen::JacobiSVD<Eigen::MatrixXd>;
+        const SvdT svdDecomposition(svdMat,
+          Eigen::ComputeThinU | Eigen::ComputeThinV);
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)