### PR TITLE
Manual forward port of: Bazel updates (#562)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header", "gz_include_header")
@@ -610,4 +611,20 @@ cc_library(
         ":thermal_camera",
         ":wide_angle_camera",
     ],
+)
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,25 +1,27 @@
-## MODULE.bazel
 module(
     name = "gz-sensors",
-    repo_name = "org_gazebosim_gz-sensors",
+    compatibility_level = 9,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-msgs")
-bazel_dep(name = "gz-rendering")
-bazel_dep(name = "gz-transport")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "sdformat")
+bazel_dep(name = "gz-common", version = "7.0.0")
+bazel_dep(name = "gz-math", version = "9.0.0")
+bazel_dep(name = "gz-msgs", version = "12.0.0")
+bazel_dep(name = "gz-rendering", version = "10.0.0")
+bazel_dep(name = "gz-transport", version = "15.0.0")
+bazel_dep(name = "gz-utils", version = "4.0.0")
+bazel_dep(name = "sdformat", version = "16.0.0")
 
+# Override Gz deps to be pulled from the `main` branches so that CI uses deps
+# from HEAD on `main`.
 archive_override(
     module_name = "gz-common",
     strip_prefix = "gz-common-main",

--- a/bazel/gz_sensor_library.bzl
+++ b/bazel/gz_sensor_library.bzl
@@ -1,3 +1,7 @@
+"""
+Rules for sensor libraries.
+"""
+
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 


### PR DESCRIPTION
The change had to be amended to apply it on main. Specifically, the repo `archive_override`s in MODULE.bazel for gz deps was removed in that PR on the Jetty branch, but we want to preserve it on main to ensure CI uses gz deps from HEAD.

-- Original PR description
Few fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR:

- Add `compatibility_level` to match what is set in BCR
- Add builidifier linting for consistent formatting of bazel files.
- Added docstring for gz_sensor_library.bzl
- Bumped rules_cc to 0.2.14 as indicated in resolved bazel build graph

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
