### PR TITLE
Manual backport of: Bazel updates (#562)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header", "gz_include_header")
@@ -610,4 +611,20 @@ cc_library(
         ":thermal_camera",
         ":wide_angle_camera",
     ],
+)
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,69 +1,21 @@
-## MODULE.bazel
 module(
     name = "gz-sensors",
-    repo_name = "org_gazebosim_gz-sensors",
+    compatibility_level = 9,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-msgs")
-bazel_dep(name = "gz-rendering")
-bazel_dep(name = "gz-transport")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "sdformat")
-
-archive_override(
-    module_name = "gz-common",
-    strip_prefix = "gz-common-gz-common6",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-math",
-    strip_prefix = "gz-math-gz-math8",
-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-msgs",
-    strip_prefix = "gz-msgs-gz-msgs11",
-    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/heads/gz-msgs11.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-rendering",
-    strip_prefix = "gz-rendering-gz-rendering9",
-    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/heads/gz-rendering9.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-plugin",
-    strip_prefix = "gz-plugin-gz-plugin3",
-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-transport",
-    strip_prefix = "gz-transport-gz-transport14",
-    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/heads/gz-transport14.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-utils",
-    strip_prefix = "gz-utils-gz-utils3",
-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
-)
-
-archive_override(
-    module_name = "sdformat",
-    strip_prefix = "sdformat-sdf15",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/heads/sdf15.tar.gz"],
-)
+bazel_dep(name = "gz-common", version = "6.2.1")
+bazel_dep(name = "gz-math", version = "8.1.1.bcr.1")
+bazel_dep(name = "gz-msgs", version = "11.1.0.bcr.2")
+bazel_dep(name = "gz-rendering", version = "9.4.0")
+bazel_dep(name = "gz-transport", version = "14.2.0.bcr.1")
+bazel_dep(name = "gz-utils", version = "3.1.1")
+bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")

--- a/bazel/gz_sensor_library.bzl
+++ b/bazel/gz_sensor_library.bzl
@@ -1,3 +1,7 @@
+"""
+Rules for sensor libraries.
+"""
+
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 


### PR DESCRIPTION
Manually backported to use Ionic packages for gz deps from BCR instead of Jetty deps.

-- Original PR description:
Few fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR:

- Remove archive_override for gazebo package deps and use Jetty packages from BCR instead. As a result, bazel CI will use released versions of gz deps, which is consistent with cmake CI.
- Add compatibility_level to match what is set in BCR
- Add builidifier linting for consistent formatting of bazel files.
- Added docstring for gz_sensor_library.bzl
- Bumped rules_cc to 0.2.14 as indicated in resolved bazel build graph

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
