### PR TITLE
Add custom point cloud frame ID support to Depth and RGBD camera sensors 

### DIFF
--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -143,6 +143,10 @@ class gz::sensors::DepthCameraSensorPrivate
 
   /// \brief publisher to publish point cloud
   public: transport::Node::Publisher pointPub;
+
+  /// \brief Custom frame ID for point cloud messages. If empty, uses the
+  /// optical frame ID.
+  public: std::string pointCloudFrameId;
 };
 
 using namespace gz;
@@ -313,6 +317,16 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
   gzdbg << "Points for [" << this->Name() << "] advertised on ["
          << this->Topic() << "/points]" << std::endl;
 
+  // Check for custom point cloud frame ID
+  if (_sdf.Element() != nullptr &&
+      _sdf.Element()->HasElement("points_frame_id"))
+  {
+    this->dataPtr->pointCloudFrameId =
+        _sdf.Element()->Get<std::string>("points_frame_id");
+    gzdbg << "Using custom point cloud frame ID: "
+          << this->dataPtr->pointCloudFrameId << std::endl;
+  }
+
   if (this->Scene())
   {
     this->CreateCamera();
@@ -440,9 +454,12 @@ bool DepthCameraSensor::CreateCamera()
         std::placeholders::_4, std::placeholders::_5));
 
   // Initialize the point message.
+  // Use custom frame ID if specified, otherwise use optical frame ID
+  const std::string frameId = this->dataPtr->pointCloudFrameId.empty() ?
+      this->OpticalFrameId() : this->dataPtr->pointCloudFrameId;
   msgs::InitPointCloudPacked(
         this->dataPtr->pointMsg,
-        this->OpticalFrameId(),
+        frameId,
         false,
         {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
          {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -133,6 +133,10 @@ class gz::sensors::RgbdCameraSensorPrivate
   /// \brief Helper class that can fill a msgs::PointCloudPacked
   /// image and depth data.
   public: PointCloudUtil pointsUtil;
+
+  /// \brief Custom frame ID for point cloud messages. If empty, uses the
+  /// optical frame ID.
+  public: std::string pointCloudFrameId;
 };
 
 using namespace gz;
@@ -236,6 +240,16 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
 
   gzdbg << "Points for [" << this->Name() << "] advertised on ["
          << this->Topic() << "/points]" << std::endl;
+
+  // Check for custom point cloud frame ID
+  if (_sdf.Element() != nullptr &&
+      _sdf.Element()->HasElement("points_frame_id"))
+  {
+    this->dataPtr->pointCloudFrameId =
+        _sdf.Element()->Get<std::string>("points_frame_id");
+    gzdbg << "Using custom point cloud frame ID: "
+          << this->dataPtr->pointCloudFrameId << std::endl;
+  }
 
   if (_sdf.CameraSensor()->Triggered())
   {
@@ -375,7 +389,10 @@ bool RgbdCameraSensor::CreateCameras()
         std::placeholders::_4, std::placeholders::_5));
 
   // Initialize the point message.
-  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->OpticalFrameId(),
+  // Use custom frame ID if specified, otherwise use optical frame ID
+  const std::string frameId = this->dataPtr->pointCloudFrameId.empty() ?
+      this->OpticalFrameId() : this->dataPtr->pointCloudFrameId;
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, frameId,
       false,
       {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
        {"rgb", msgs::PointCloudPacked::Field::FLOAT32}});

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 #include <cstring>
 #include <string>
@@ -31,7 +31,7 @@
 // warnings
 #ifdef _WIN32
 #pragma warning(push)
-#pragma warning(disable: 4251)
+#pragma warning(disable : 4251)
 #endif
 #include <gz/rendering/Material.hh>
 #include <gz/rendering/RenderEngine.hh>
@@ -64,7 +64,7 @@ float *g_pointsXYZBuffer = nullptr;
 unsigned char *g_pointsRGBBuffer = nullptr;
 
 void UnpackPointCloudMsg(const gz::msgs::PointCloudPacked &_msg,
-  float *_xyzBuffer, unsigned char *_rgbBuffer)
+                         float *_xyzBuffer, unsigned char *_rgbBuffer)
 {
   std::string msgBuffer = _msg.data();
   char *msgBufferIndex = msgBuffer.data();
@@ -74,14 +74,14 @@ void UnpackPointCloudMsg(const gz::msgs::PointCloudPacked &_msg,
     for (uint32_t i = 0; i < _msg.width(); ++i)
     {
       int fieldIndex = 0;
-      int pointIndex = j*_msg.width()*3 + i*3;
+      int pointIndex = j * _msg.width() * 3 + i * 3;
 
-      _xyzBuffer[pointIndex] =  *reinterpret_cast<float *>(
-        msgBufferIndex + _msg.field(fieldIndex++).offset());
+      _xyzBuffer[pointIndex] = *reinterpret_cast<float *>(
+          msgBufferIndex + _msg.field(fieldIndex++).offset());
       _xyzBuffer[pointIndex + 1] = *reinterpret_cast<float *>(
-        msgBufferIndex + _msg.field(fieldIndex++).offset());
+          msgBufferIndex + _msg.field(fieldIndex++).offset());
       _xyzBuffer[pointIndex + 2] = *reinterpret_cast<float *>(
-        msgBufferIndex + _msg.field(fieldIndex++).offset());
+          msgBufferIndex + _msg.field(fieldIndex++).offset());
 
       int fieldOffset = _msg.field(fieldIndex).offset();
       if (_msg.is_bigendian())
@@ -101,7 +101,7 @@ void UnpackPointCloudMsg(const gz::msgs::PointCloudPacked &_msg,
   }
 }
 
-void OnCameraInfo(const gz::msgs::CameraInfo & _msg)
+void OnCameraInfo(const gz::msgs::CameraInfo &_msg)
 {
   g_infoMutex.lock();
   g_infoCounter++;
@@ -138,11 +138,12 @@ void OnPointCloud(const gz::msgs::PointCloudPacked &_msg)
   g_pcMutex.unlock();
 }
 
-class DepthCameraSensorTest: public testing::Test,
-  public testing::WithParamInterface<const char *>
+class DepthCameraSensorTest : public testing::Test,
+                              public testing::WithParamInterface<const char *>
 {
   // Documentation inherited
-  protected: void SetUp() override
+protected:
+  void SetUp() override
   {
     // Disable Ogre tests on windows. See
     // https://github.com/gazebosim/gz-sensors/issues/284
@@ -154,21 +155,28 @@ class DepthCameraSensorTest: public testing::Test,
 #endif
   }
   // Create a Camera sensor from a SDF and gets a image message
-  public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+public:
+  void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 
   // Create depth camera sensors and verify camera intrinsics
-  public: void DepthCameraIntrinsics(const std::string &_renderEngine);
+public:
+  void DepthCameraIntrinsics(const std::string &_renderEngine);
 
   // Create depth camera sensors and verify camera projection
-  public: void DepthCameraProjection(const std::string &_renderEngine);
+public:
+  void DepthCameraProjection(const std::string &_renderEngine);
+
+  // Test custom point cloud frame ID
+public:
+  void CustomPointCloudFrameId(const std::string &_renderEngine);
 };
 
 void DepthCameraSensorTest::ImagesWithBuiltinSDF(
     const std::string &_renderEngine)
 {
   // get the darn test data
-  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
-      "sdf", "depth_camera_sensor_builtin.sdf");
+  std::string path = gz::common::joinPaths(
+    PROJECT_SOURCE_PATH, "test", "sdf", "depth_camera_sensor_builtin.sdf");
   sdf::SDFPtr doc(new sdf::SDF());
   sdf::init(doc);
   ASSERT_TRUE(sdf::readFile(path, doc));
@@ -199,7 +207,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
       (_renderEngine.compare("ogre2") != 0))
   {
     gzdbg << "Engine '" << _renderEngine
-              << "' doesn't support depth cameras" << std::endl;
+          << "' doesn't support depth cameras" << std::endl;
     return;
   }
 
@@ -208,7 +216,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   if (!engine)
   {
     gzdbg << "Engine '" << _renderEngine
-              << "' is not supported" << std::endl;
+          << "' is not supported" << std::endl;
     return;
   }
 
@@ -252,17 +260,17 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   EXPECT_NEAR(depthSensor->NearClip(), near_, DOUBLE_TOL);
 
   std::string topic =
-    "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image";
+      "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image";
   WaitForMessageTestHelper<gz::msgs::Image> helper(topic);
   EXPECT_TRUE(depthSensor->HasConnections());
 
   std::string pointsTopic =
-    "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image/points";
+      "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/image/points";
   WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
-    pointsHelper(pointsTopic);
+      pointsHelper(pointsTopic);
 
   std::string infoTopic =
-    "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/camera_info";
+      "/test/integration/DepthCameraPlugin_imagesWithBuiltinSDF/camera_info";
   WaitForMessageTestHelper<gz::msgs::CameraInfo> infoHelper(infoTopic);
 
   // Update once to create image
@@ -287,11 +295,11 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
 
   int midWidth = static_cast<int>(depthSensor->ImageWidth() * 0.5);
   int midHeight = static_cast<int>(depthSensor->ImageHeight() * 0.5);
-  int mid = midHeight * depthSensor->ImageWidth() + midWidth -1;
+  int mid = midHeight * depthSensor->ImageWidth() + midWidth - 1;
   double expectedRangeAtMidPoint = boxPosition.X() - unitBoxSize * 0.5;
 
-  auto waitTime = std::chrono::duration_cast< std::chrono::milliseconds >(
-      std::chrono::duration< double >(0.001));
+  auto waitTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::duration<double>(0.001));
   int counter = 0;
   int infoCounter = 0;
   int pcCounter = 0;
@@ -327,7 +335,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   // The left and right side of the depth frame should be inf
   int left = midHeight * depthSensor->ImageWidth();
   EXPECT_DOUBLE_EQ(g_depthBuffer[left], gz::math::INF_D);
-  int right = (midHeight+1) * depthSensor->ImageWidth() - 1;
+  int right = (midHeight + 1) * depthSensor->ImageWidth() - 1;
   EXPECT_DOUBLE_EQ(g_depthBuffer[right], gz::math::INF_D);
   g_infoMutex.unlock();
   g_mutex.unlock();
@@ -340,7 +348,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   EXPECT_EQ("camera1", infoMsg.header().data(0).value(0));
   EXPECT_TRUE(infoMsg.has_distortion());
   EXPECT_EQ(gz::msgs::CameraInfo::Distortion::PLUMB_BOB,
-      infoMsg.distortion().model());
+            infoMsg.distortion().model());
   EXPECT_EQ(5, infoMsg.distortion().k().size());
   EXPECT_TRUE(infoMsg.has_intrinsics());
   EXPECT_EQ(9, infoMsg.intrinsics().k().size());
@@ -415,7 +423,6 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   g_infoMutex.unlock();
   g_mutex.unlock();
 
-
   // Check that the depth values for a box do not warp.
   gz::math::Vector3d boxPositionFillFrame(
       unitBoxSize * 0.5 + 0.2, 0.0, 0.0);
@@ -461,7 +468,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
     // all points should have the same depth
     for (unsigned int i = 0; i < depthSensor->ImageHeight(); ++i)
     {
-      unsigned int step = i*depthSensor->ImageWidth();
+      unsigned int step = i * depthSensor->ImageWidth();
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         float d = g_depthBuffer[step + j];
@@ -474,10 +481,10 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
     // all points should have the same X value
     for (unsigned int i = 0; i < depthSensor->ImageHeight(); ++i)
     {
-      unsigned int step = i*depthSensor->ImageWidth()*3;
+      unsigned int step = i * depthSensor->ImageWidth() * 3;
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
-        float x = g_pointsXYZBuffer[step + j*3];
+        float x = g_pointsXYZBuffer[step + j * 3];
         EXPECT_NEAR(expectedDepth, x, DOUBLE_TOL);
       }
     }
@@ -486,15 +493,15 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
     // all points should be the same
     for (unsigned int i = 0; i < depthSensor->ImageHeight(); ++i)
     {
-      unsigned int step = i*depthSensor->ImageWidth()*3;
+      unsigned int step = i * depthSensor->ImageWidth() * 3;
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         unsigned int r =
-            static_cast<unsigned int>(g_pointsRGBBuffer[step + j*3]);
+            static_cast<unsigned int>(g_pointsRGBBuffer[step + j * 3]);
         unsigned int g =
-            static_cast<unsigned int>(g_pointsRGBBuffer[step + j*3 + 1]);
+            static_cast<unsigned int>(g_pointsRGBBuffer[step + j * 3 + 1]);
         unsigned int b =
-            static_cast<unsigned int>(g_pointsRGBBuffer[step + j*3 + 2]);
+            static_cast<unsigned int>(g_pointsRGBBuffer[step + j * 3 + 2]);
         EXPECT_EQ(g, r);
         EXPECT_EQ(b, g);
       }
@@ -526,8 +533,9 @@ TEST_P(DepthCameraSensorTest, ImagesWithBuiltinSDF)
 void DepthCameraSensorTest::DepthCameraIntrinsics(
     const std::string &_renderEngine)
 {
-  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
-      "sdf", "depth_camera_intrinsics.sdf");
+  std::string path = gz::common::joinPaths(
+    PROJECT_SOURCE_PATH, "test", "sdf", "depth_camera_intrinsics.sdf");
+
   sdf::SDFPtr doc(new sdf::SDF());
   sdf::init(doc);
   ASSERT_TRUE(sdf::readFile(path, doc));
@@ -627,20 +635,20 @@ void DepthCameraSensorTest::DepthCameraIntrinsics(
   unsigned int camera2Counter = 0u;
   unsigned int camera3Counter = 0u;
 
-  std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
-      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera1InfoCallback =
+      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera1Info = _msg;
     camera1Counter++;
   };
-  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
-      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera2InfoCallback =
+      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera2Info = _msg;
     camera2Counter++;
   };
-  std::function<void(const gz::msgs::CameraInfo&)> camera3InfoCallback =
-      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera3InfoCallback =
+      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera3Info = _msg;
     camera3Counter++;
@@ -715,8 +723,9 @@ TEST_P(DepthCameraSensorTest, CameraIntrinsics)
 void DepthCameraSensorTest::DepthCameraProjection(
     const std::string &_renderEngine)
 {
-  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
-      "sdf", "depth_camera_projection.sdf");
+  std::string path = gz::common::joinPaths(
+    PROJECT_SOURCE_PATH, "test", "sdf", "depth_camera_projection.sdf");
+
   sdf::SDFPtr doc(new sdf::SDF());
   sdf::init(doc);
   ASSERT_TRUE(sdf::readFile(path, doc));
@@ -810,20 +819,20 @@ void DepthCameraSensorTest::DepthCameraProjection(
   unsigned int camera2Counter = 0u;
   unsigned int camera3Counter = 0u;
 
-  std::function<void(const gz::msgs::CameraInfo&)> camera1InfoCallback =
-      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera1InfoCallback =
+      [&camera1Info, &camera1Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera1Info = _msg;
     camera1Counter++;
   };
-  std::function<void(const gz::msgs::CameraInfo&)> camera2InfoCallback =
-      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera2InfoCallback =
+      [&camera2Info, &camera2Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera2Info = _msg;
     camera2Counter++;
   };
-  std::function<void(const gz::msgs::CameraInfo&)> camera3InfoCallback =
-      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo& _msg)
+  std::function<void(const gz::msgs::CameraInfo &)> camera3InfoCallback =
+      [&camera3Info, &camera3Counter](const gz::msgs::CameraInfo &_msg)
   {
     camera3Info = _msg;
     camera3Counter++;
@@ -903,5 +912,98 @@ TEST_P(DepthCameraSensorTest, CameraProjection)
   DepthCameraProjection(GetParam());
 }
 
-INSTANTIATE_TEST_SUITE_P(DepthCameraSensor, DepthCameraSensorTest,
-    RENDER_ENGINE_VALUES, gz::rendering::PrintToStringParam());
+//////////////////////////////////////////////////
+void DepthCameraSensorTest::CustomPointCloudFrameId(
+    const std::string &_renderEngine)
+{
+  if ((_renderEngine.compare("ogre") != 0) &&
+      (_renderEngine.compare("ogre2") != 0))
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' doesn't support depth cameras" << std::endl;
+    return;
+  }
+
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  std::string path = gz::common::joinPaths(
+    PROJECT_SOURCE_PATH, "test", "sdf", "depth_camera_points_frame_id.sdf");
+
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+
+  auto sensorPtr1 = linkPtr->GetElement("sensor");
+  auto sensorPtr2 =
+      linkPtr->GetElement("sensor")->GetNextElement();
+
+  gz::sensors::Manager mgr;
+  gz::sensors::DepthCameraSensor *cameraWithoutPclFrameId
+    = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(sensorPtr1);
+  gz::sensors::DepthCameraSensor *cameraWithPclFrameId
+    = mgr.CreateSensor<gz::sensors::DepthCameraSensor>(sensorPtr2);
+
+  ASSERT_NE(nullptr, cameraWithoutPclFrameId);
+  ASSERT_NE(nullptr, cameraWithPclFrameId);
+
+  cameraWithoutPclFrameId->SetScene(scene);
+  cameraWithPclFrameId->SetScene(scene);
+
+  WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
+      pointsHelper1("/camera1/image/points");
+  WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
+      pointsHelper2("/camera2/image/points");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      imageHelper1("/camera1/image");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      imageHelper2("/camera2/image");
+
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  EXPECT_TRUE(pointsHelper1.WaitForMessage()) << pointsHelper1;
+  EXPECT_TRUE(pointsHelper2.WaitForMessage()) << pointsHelper2;
+  EXPECT_TRUE(imageHelper1.WaitForMessage()) << imageHelper1;
+  EXPECT_TRUE(imageHelper2.WaitForMessage()) << imageHelper2;
+
+  auto pointsMsg1 = pointsHelper1.Message();
+  auto pointsMsg2 = pointsHelper2.Message();
+  auto imageMsg1 = imageHelper1.Message();
+  auto imageMsg2 = imageHelper2.Message();
+
+  EXPECT_EQ("optical_frame", pointsMsg1.header().data(0).value(0));
+  EXPECT_EQ("points_frame", pointsMsg2.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", imageMsg1.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", imageMsg2.header().data(0).value(0));
+
+  mgr.Remove(cameraWithoutPclFrameId->Id());
+  mgr.Remove(cameraWithPclFrameId->Id());
+
+  // Clean up
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(DepthCameraSensorTest, CustomPointCloudFrameId)
+{
+  gz::common::Console::SetVerbosity(4);
+  CustomPointCloudFrameId(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  DepthCameraSensor, DepthCameraSensorTest,
+  RENDER_ENGINE_VALUES, gz::rendering::PrintToStringParam());

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -175,6 +175,9 @@ class RgbdCameraSensorTest: public testing::Test,
 
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+
+  // Test custom point cloud frame ID
+  public: void CustomPointCloudFrameId(const std::string &_renderEngine);
 };
 
 void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
@@ -759,6 +762,110 @@ TEST_P(RgbdCameraSensorTest, ImagesWithBuiltinSDF)
 {
   common::Console::SetVerbosity(4);
   ImagesWithBuiltinSDF(GetParam());
+}
+
+//////////////////////////////////////////////////
+void RgbdCameraSensorTest::CustomPointCloudFrameId(
+    const std::string &_renderEngine)
+{
+  if ((_renderEngine.compare("ogre") != 0) &&
+      (_renderEngine.compare("ogre2") != 0))
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' doesn't support depth cameras" << std::endl;
+    return;
+  }
+
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    gzdbg << "Engine '" << _renderEngine
+          << "' is not supported" << std::endl;
+    return;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  std::string path = gz::common::joinPaths(
+    PROJECT_SOURCE_PATH, "test", "sdf", "rgbd_camera_points_frame_id.sdf");
+
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+
+  auto sensorPtr1 = linkPtr->GetElement("sensor");
+  auto sensorPtr2 =
+      linkPtr->GetElement("sensor")->GetNextElement();
+
+  gz::sensors::Manager mgr;
+  auto* cameraWithoutPclFrameId
+    = mgr.CreateSensor<gz::sensors::RgbdCameraSensor>(sensorPtr1);
+  auto* cameraWithPclFrameId
+    = mgr.CreateSensor<gz::sensors::RgbdCameraSensor>(sensorPtr2);
+  ASSERT_NE(nullptr, cameraWithoutPclFrameId);
+  ASSERT_NE(nullptr, cameraWithPclFrameId);
+
+  cameraWithoutPclFrameId->SetScene(scene);
+  cameraWithPclFrameId->SetScene(scene);
+
+  WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
+      pointsHelper1("/camera1/image/points");
+  WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
+      pointsHelper2("/camera2/image/points");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      imageHelper1("/camera1/image/image");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      imageHelper2("/camera2/image/image");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      depthImageHelper1("/camera1/image/depth_image");
+  WaitForMessageTestHelper<gz::msgs::Image>
+      depthImageHelper2("/camera2/image/depth_image");
+
+  EXPECT_TRUE(cameraWithoutPclFrameId->HasConnections());
+  EXPECT_TRUE(cameraWithPclFrameId->HasConnections());
+
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  EXPECT_TRUE(pointsHelper1.WaitForMessage()) << pointsHelper1;
+  EXPECT_TRUE(pointsHelper2.WaitForMessage()) << pointsHelper2;
+  EXPECT_TRUE(depthImageHelper1.WaitForMessage()) << depthImageHelper1;
+  EXPECT_TRUE(depthImageHelper2.WaitForMessage()) << depthImageHelper2;
+  EXPECT_TRUE(imageHelper1.WaitForMessage()) << imageHelper1;
+  EXPECT_TRUE(imageHelper2.WaitForMessage()) << imageHelper2;
+
+  auto pointsMsg1 = pointsHelper1.Message();
+  auto pointsMsg2 = pointsHelper2.Message();
+  auto imageMsg1 = imageHelper1.Message();
+  auto imageMsg2 = imageHelper2.Message();
+  auto depthImageMsg1 = depthImageHelper1.Message();
+  auto depthImageMsg2 = depthImageHelper2.Message();
+
+  EXPECT_EQ("optical_frame", pointsMsg1.header().data(0).value(0));
+  EXPECT_EQ("points_frame", pointsMsg2.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", imageMsg1.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", imageMsg2.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", depthImageMsg1.header().data(0).value(0));
+  EXPECT_EQ("optical_frame", depthImageMsg2.header().data(0).value(0));
+
+  mgr.Remove(cameraWithoutPclFrameId->Id());
+  mgr.Remove(cameraWithPclFrameId->Id());
+
+  // Clean up
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(RgbdCameraSensorTest, CustomPointCloudFrameId)
+{
+  common::Console::SetVerbosity(4);
+  CustomPointCloudFrameId(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(RgbdCameraSensor, RgbdCameraSensorTest,

--- a/test/sdf/depth_camera_points_frame_id.sdf
+++ b/test/sdf/depth_camera_points_frame_id.sdf
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera_without_points_frame_id" type="depth">
+        <update_rate>10</update_rate>
+        <frame_id>optical_frame</frame_id>
+        <topic>/camera1/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+          </image>
+        </camera>
+      </sensor>
+      <sensor name="camera_with_points_frame_id" type="depth">
+        <update_rate>10</update_rate>
+        <frame_id>optical_frame</frame_id>
+        <points_frame_id>points_frame</points_frame_id>
+        <topic>/camera2/image</topic>
+        <camera>
+          <horizontal_fov>1.0472</horizontal_fov>
+          <image>
+            <width>1000</width>
+            <height>1000</height>
+          </image>
+          <lens>
+            <projection>
+              <p_fx>866.23</p_fx>
+              <p_fy>866.23</p_fy>
+              <p_cx>500</p_cx>
+              <p_cy>500</p_cy>
+              <tx>300</tx>
+              <ty>200</ty>
+            </projection>
+          </lens>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/sdf/rgbd_camera_points_frame_id.sdf
+++ b/test/sdf/rgbd_camera_points_frame_id.sdf
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera1" type="rgbd_camera">
+        <update_rate>10</update_rate>
+        <topic>/camera1/image</topic>
+        <frame_id>optical_frame</frame_id>
+        <camera>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>256</width>
+            <height>256</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+        </camera>
+      </sensor>
+      <sensor name="camera2" type="rgbd_camera">
+        <update_rate>10</update_rate>
+        <topic>/camera2/image</topic>
+        <frame_id>optical_frame</frame_id>
+        <points_frame_id>points_frame</points_frame_id>
+        <camera>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>256</width>
+            <height>256</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

Closes #488 

## Summary
**The problem**
Currently, the depth and rgbd cameras use the content from the `<frame_id>` tag or the default frameId for both the 
the images and the point cloud. However, the images typically need an optical frame id while the point cloud needs a "sensor" frame id. 

**The Solution**
This proposed change enables depth and rbgd camera sensors to include a new `<points_frame_id>` tag to use for the point cloud messages. This is not a breaking change, because when the tag is not included, behavior is unchanged.

Example:
```xml
      <sensor name="camera_with_points_frame_id" type="depth">
        <update_rate>10</update_rate>
        <frame_id>optical_frame</frame_id>
        <points_frame_id>points_frame</points_frame_id>
        <topic>/camera2/image</topic>
        <camera>
          <horizontal_fov>1.0472</horizontal_fov>
          <image>
            <width>1000</width>
            <height>1000</height>
          </image>
          <lens>
            <projection>
              <p_fx>866.23</p_fx>
              <p_fy>866.23</p_fy>
              <p_cx>500</p_cx>
              <p_cy>500</p_cy>
              <tx>300</tx>
              <ty>200</ty>
            </projection>
          </lens>
        </camera>
      </sensor>
 ```

## Test it
To test manually, launch gazebo sim with a urdf containing a depth camera that uses the new tag. Then verify frame ids on the images and point clouds are correct.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.