### PR TITLE
Use rotary alias packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,9 +1,9 @@
-libgz-cmake5-dev
-libgz-common7-dev
-libgz-math9-dev
-libgz-msgs12-dev
-libgz-rendering10-dev
-libgz-tools2-dev
-libgz-transport15-dev
-libsdformat16-dev
+libgz-rotary-cmake-dev
+libgz-rotary-common-dev
+libgz-rotary-math-dev
+libgz-rotary-msgs-dev
+libgz-rotary-rendering-dev
+libgz-rotary-tools-dev
+libgz-rotary-transport-dev
+libgz-rotary-sdformat-dev
 xvfb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          gzdev-project-name: rotary
           # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true


### PR DESCRIPTION
Use rotary alias packages for CI

Related to https://github.com/gazebo-tooling/release-tools/issues/1446