### PR TITLE
Use GTEST_SKIP in unsupported tests

### DIFF
--- a/test/integration/boundingbox_camera.cc
+++ b/test/integration/boundingbox_camera.cc
@@ -216,18 +216,16 @@ void BoundingBoxCameraSensorTest::BoxesWithBuiltinSDF(
   // Skip unsupported engines
   if (_renderEngine != "ogre2")
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support bounding box cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -385,18 +383,16 @@ void BoundingBoxCameraSensorTest::Boxes3DWithBuiltinSDF(
   // Skip unsupported engines
   if (_renderEngine != "ogre2")
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support bounding box cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -116,9 +116,8 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -218,9 +217,8 @@ void CameraSensorTest::CameraIntrinsics(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
           << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -515,9 +513,8 @@ void CameraSensorTest::CameraProjection(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
           << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -807,9 +804,8 @@ void CameraSensorTest::ImageFormatLInt8LInt16(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -198,9 +198,8 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   if ((_renderEngine.compare("ogre") != 0) &&
       (_renderEngine.compare("ogre2") != 0))
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support depth cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -82,7 +82,9 @@ void DistortionCameraSensorTest::ImagesWithBuiltinSDF(
   if (_renderEngine == "ogre2")
   {
     GTEST_SKIP() << "Distortion camera not supported yet in rendering engine: "
-            << _renderEngine << std::endl;
+                 << _renderEngine
+                 << ", see https://github.com/gazebosim/gz-rendering/issues/697"
+                 << std::endl;
   }
 
   // Setup gz-rendering with an empty scene

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -81,18 +81,16 @@ void DistortionCameraSensorTest::ImagesWithBuiltinSDF(
 
   if (_renderEngine == "ogre2")
   {
-    gzdbg << "Distortion camera not supported yet in rendering engine: "
+    GTEST_SKIP() << "Distortion camera not supported yet in rendering engine: "
             << _renderEngine << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/dvl.cc
+++ b/test/integration/dvl.cc
@@ -240,8 +240,11 @@ class DopplerVelocityLogTest : public testing::Test,
   // Documentation inherited
   protected: void TearDown() override
   {
-    engine->DestroyScene(scene);
-    rendering::unloadEngine(engine->Name());
+    if (engine)
+    {
+      engine->DestroyScene(scene);
+      rendering::unloadEngine(engine->Name());
+    }
   }
 
   rendering::RenderEngine *engine{nullptr};

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -209,9 +209,8 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -330,9 +329,8 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
     gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -502,9 +500,8 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
     gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -651,9 +648,8 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
     gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -787,9 +783,8 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
     gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -897,9 +892,8 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
   auto engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
   auto scene = engine->CreateScene("scene");
   EXPECT_NE(nullptr, scene);

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -212,18 +212,16 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
   if ((_renderEngine.compare("ogre") != 0) &&
       (_renderEngine.compare("ogre2") != 0))
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support rgbd cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/segmentation_camera.cc
+++ b/test/integration/segmentation_camera.cc
@@ -191,17 +191,15 @@ void SegmentationCameraSensorTest::ImagesWithBuiltinSDF(
   // If ogre2 is not the engine, don't run the test
   if (_renderEngine.compare("ogre2") != 0)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
       << "' doesn't support segmentation cameras" << std::endl;
-    return;
   }
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -151,18 +151,16 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
   if ((_renderEngine.compare("ogre") != 0) &&
       (_renderEngine.compare("ogre2") != 0))
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support thermal cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -421,18 +419,16 @@ void ThermalCameraSensorTest::Images8BitWithBuiltinSDF(
   // If ogre2 is not the engine, don't run the test
   if ((_renderEngine.compare("ogre2") != 0))
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' doesn't support 8 bit thermal cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/triggered_boundingbox_camera.cc
+++ b/test/integration/triggered_boundingbox_camera.cc
@@ -135,18 +135,16 @@ void TriggeredBoundingBoxCameraTest::BoxesWithBuiltinSDF(
     // Skip unsupported engines
   if (_renderEngine != "ogre2")
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' doesn't support bounding box cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -238,18 +236,16 @@ void TriggeredBoundingBoxCameraTest::EmptyTriggerTopic(
     // Skip unsupported engines
   if (_renderEngine != "ogre2")
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' doesn't support bounding box cameras" << std::endl;
-    return;
   }
 
   // Setup gz-rendering with an empty scene
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/triggered_camera.cc
+++ b/test/integration/triggered_camera.cc
@@ -87,9 +87,8 @@ void TriggeredCameraTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
@@ -182,9 +181,8 @@ void TriggeredCameraTest::EmptyTriggerTopic(const std::string &_renderEngine)
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -120,9 +120,8 @@ void WideAngleCameraSensorTest::ImagesWithBuiltinSDF(
   auto *engine = gz::rendering::engine(_renderEngine);
   if (!engine)
   {
-    gzdbg << "Engine '" << _renderEngine
+    GTEST_SKIP() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
-    return;
   }
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-rendering/issues/1235

## Summary

While checking whether `gz-sensors` tests are using ogre2 on macOS, I noticed that very few tests are using `GTEST_SKIP()` for unsupported engines, so this switches the `gzdbg` stream then `return` pattern to stream directly to `GTEST_SKIP()` as is [done in gz-rendering](https://github.com/gazebosim/gz-rendering/blob/15a0455307f002e9a5e1415198ebbd7ab5731c1b/test/common_test/CommonRenderingTest.hh#L101).

On Ubuntu, this shows an [increase of 1 skipped test](https://build.osrfoundation.org/job/gz_sensors-ci-pr_any-noble-amd64/155/testReport/(root)/):
* [DistortionCameraSensor/DistortionCameraSensorTest.ImagesWithBuiltinSDF/ogre2](https://build.osrfoundation.org/job/gz_sensors-ci-pr_any-noble-amd64/156/testReport/(root)/DistortionCameraSensor_DistortionCameraSensorTest/ImagesWithBuiltinSDF_ogre2/)

On macOS, there are [many new skipped tests](https://build.osrfoundation.org/job/gz_sensors-ci-pr_any-homebrew-arm64/60/testReport/(root)/) due to the removal of `ogre1.9` in https://github.com/osrf/homebrew-simulation/pull/3394 (see follow-up work in #605).

This also fixes a segfault of `INTEGRATION_dvl` when the render engine plugin fails to load, which also started failing on macOS when `ogre1.9` was removed in https://github.com/osrf/homebrew-simulation/pull/3394.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
