### PR TITLE
ci.yml: test on Ubuntu 26.04 Resolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,27 @@ jobs:
     name: Ubuntu Noble CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
           gzdev-project-name: rotary
           # codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true
+  resolute-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Resolute CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@resolute
+        with:
+          gzdev-project-name: rotary
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true

--- a/include/gz/sensors/DopplerVelocityLog.hh
+++ b/include/gz/sensors/DopplerVelocityLog.hh
@@ -130,8 +130,8 @@ namespace gz
     /// - `<tracking><bottom_mode>` configures the bottom tracking mode.
     /// - `<tracking><bottom_mode><when>` enables (or disables) the bottom
     /// tracking mode. Supported values are 'never', to disable it completely
-    /// (as if no <bottom_mode> configuration had been specified), 'always' to
-    /// enable it at all times, and 'best' to track at all times but only
+    /// (as if no `<bottom_mode>` configuration had been specified), 'always'
+    /// to enable it at all times, and 'best' to track at all times but only
     /// publish estimates when it performs best among all configured modes.
     /// Defaults to 'always' if left unspecified.
     /// - `<tracking><bottom_mode><noise>` sets the noise model for velocity
@@ -145,7 +145,7 @@ namespace gz
     /// mode.
     /// - `<tracking><water_mass_mode><when>` enables (or disables) the
     /// water-mass tracking mode. Supported values are 'never', to disable it
-    /// completely (as if no <water_mass_mode> configuration had been
+    /// completely (as if no `<water_mass_mode>` configuration had been
     /// specified), 'always' to enable it at all times, and 'best' to track at
     /// all times but only publish estimates when it performs best among all
     /// configured modes. Defaults to 'always' if left unspecified.

--- a/include/gz/sensors/SensorTypes.hh
+++ b/include/gz/sensors/SensorTypes.hh
@@ -25,11 +25,9 @@
 #include <gz/sensors/Export.hh>
 
 /// \file
-/// \ingroup gz_sensors
 /// \brief Forward declarations and typedefs for sensors
 namespace gz
 {
-  /// \ingroup gz_sensors
   /// \brief Sensors namespace
   namespace sensors
   {


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1485

## Summary

Enable Ubuntu CI on 26.04 with the `resolute` branch of action-gz-ci. Also update actions/checkout to v6

## Test it

Verify that CI passes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
