### PR TITLE
[bazel] Fix build on macos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -247,11 +247,13 @@ gz_sensor_library(
     visibility = ["//visibility:public"],
     deps = [
         ":gz-sensors",
+        "@gz-common",
         "@gz-common//profiler",
         "@gz-math",
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
+        "@gz-utils//:ImplPtr",
         "@gz-utils//:SuppressWarning",
         "@sdformat",
     ],


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes the following bazel build errors for `:cpu_lidar` on MacOS or with clang, more generally:
```
external/gz-sensors~/include/gz/sensors/CpuLidarSensor.hh:28:10: error: module gz-sensors~//:cpu_lidar does not depend on a module exporting 'gz/utils/ImplPtr.hh'
external/gz-sensors+/src/CpuLidarSensor.cc:24:10: error: module gz-sensors+//:cpu_lidar does not depend on a module exporting 'gz/common/Console.hh'
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
