### PR TITLE
fix: Add useRosConvention flag to output RGBD point clouds w.r.t. ROS frame conventions

### DIFF
--- a/src/CameraSensorUtil.hh
+++ b/src/CameraSensorUtil.hh
@@ -18,6 +18,9 @@
 #ifndef GZ_SENSORS_CAMERASENSORUTIL_HH_
 #define GZ_SENSORS_CAMERASENSORUTIL_HH_
 
+#include <sdf/Camera.hh>
+#include <sdf/Sensor.hh>
+
 #include <gz/math/Matrix4.hh>
 
 #include "gz/sensors/config.hh"
@@ -87,6 +90,17 @@ math::Matrix4d buildProjectionMatrix(double _imageWidth, double _imageHeight,
                                      double _intrinsicsCx, double _intrinsicsCy,
                                      double _intrinsicsS, double _clipNear,
                                      double _clipFar);
+
+/// \brief Read the <gz:use_ros_convention> element from a camera sensor SDF.
+/// \param[in] _sdf Sensor SDF to inspect.
+/// \return True if the element is present and set to true, false otherwise.
+inline bool useRosConvention(const sdf::Sensor &_sdf)
+{
+  const sdf::Camera *cam = _sdf.CameraSensor();
+  return cam && cam->Element() &&
+         cam->Element()->HasElement("gz:use_ros_convention") &&
+         cam->Element()->Get<bool>("gz:use_ros_convention");
+}
 }
 }
 }

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -134,6 +134,10 @@ class gz::sensors::DepthCameraSensor::Implementation
   /// \brief SDF Sensor DOM object.
   public: sdf::Sensor sdfSensor;
 
+  /// \brief If true, publish point cloud coordinates in the ROS optical frame
+  /// convention (X right, Y down, Z forward/depth).
+  public: bool useRosConvention = false;
+
   /// \brief The point cloud message.
   public: msgs::PointCloudPacked pointMsg;
 
@@ -268,6 +272,8 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
   }
 
   this->dataPtr->sdfSensor = _sdf;
+
+  this->dataPtr->useRosConvention = useRosConvention(_sdf);
 
   if (this->Topic().empty())
     this->SetTopic("/camera/depth");
@@ -648,7 +654,8 @@ bool DepthCameraSensor::Update(
     // fill the point cloud msg with data from xyz and rgb buffer
     this->dataPtr->pointsUtil.FillMsg(this->dataPtr->pointMsg,
         this->dataPtr->xyzBuffer,
-        this->dataPtr->image.Data<unsigned char>());
+        this->dataPtr->image.Data<unsigned char>(),
+        this->dataPtr->useRosConvention);
 
     this->AddSequence(this->dataPtr->pointMsg.mutable_header(), "pointMsg");
     this->dataPtr->pointPub.Publish(this->dataPtr->pointMsg);

--- a/src/PointCloudUtil.cc
+++ b/src/PointCloudUtil.cc
@@ -25,7 +25,7 @@ using namespace sensors;
 //////////////////////////////////////////////////
 void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
     const math::Angle &_hfov, const unsigned char *_imageData,
-    const float *_depthData) const
+    const float *_depthData, bool _useRosConvention) const
 {
   // Fill message. Logic borrowed from
   // https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_plugins/src/gazebo_ros_depth_camera.cpp
@@ -65,14 +65,30 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
       if (fl > 0 && width > 1)
         yAngle = std::atan2(0.5 * (width - 1) - i, fl);
 
-      *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = depth;
-      *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) =
-        depth * std::tan(yAngle);
-      *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) =
-        depth * std::tan(pAngle);
+      // Gazebo body frame: X=forward(depth), Y=left, Z=up
+      // ROS optical frame: X=right, Y=down, Z=forward(depth)
+      if (_useRosConvention)
+      {
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) =
+          -depth * std::tan(yAngle);
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) =
+          -depth * std::tan(pAngle);
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) = depth;
+      }
+      else
+      {
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) = depth;
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) =
+          depth * std::tan(yAngle);
+        *reinterpret_cast<float*>(msgBufferIndex +
+            _msg.field(fieldIndex++).offset()) =
+          depth * std::tan(pAngle);
+      }
 
       int imgIndex = i * 3 + j * width * 3;
       int fieldOffset = _msg.field(fieldIndex).offset();
@@ -99,7 +115,8 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
 
 //////////////////////////////////////////////////
 void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
-    const float *_xyzData, const unsigned char *_imageData) const
+    const float *_xyzData, const unsigned char *_imageData,
+    bool _useRosConvention) const
 {
   uint32_t width = _msg.width();
   uint32_t height = _msg.height();
@@ -131,12 +148,15 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
       }
 
       int fieldIndex = 0;
+      float outX = _useRosConvention ? -y : x;
+      float outY = _useRosConvention ? -z : y;
+      float outZ = _useRosConvention ?  x : z;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = x;
+          _msg.field(fieldIndex++).offset()) = outX;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = y;
+          _msg.field(fieldIndex++).offset()) = outY;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = z;
+          _msg.field(fieldIndex++).offset()) = outZ;
 
       uint8_t r = static_cast<uint8_t>(_imageData[index]);
       uint8_t g = static_cast<uint8_t>(_imageData[index + 1]);
@@ -168,7 +188,7 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
 void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
     const float *_pointCloudData, bool _writeToBuffers,
     unsigned char *_imageData,
-    float *_xyzData) const
+    float *_xyzData, bool _useRosConvention) const
 {
   uint32_t width = _msg.width();
   uint32_t height = _msg.height();
@@ -202,12 +222,15 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
       float rgba = _pointCloudData[pcIndex + 3];
 
       int fieldIndex = 0;
+      float outX = _useRosConvention ? -y : x;
+      float outY = _useRosConvention ? -z : y;
+      float outZ = _useRosConvention ?  x : z;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = x;
+          _msg.field(fieldIndex++).offset()) = outX;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = y;
+          _msg.field(fieldIndex++).offset()) = outY;
       *reinterpret_cast<float*>(msgBufferIndex +
-          _msg.field(fieldIndex++).offset()) = z;
+          _msg.field(fieldIndex++).offset()) = outZ;
 
       uint8_t r = 0u;
       uint8_t g = 0u;
@@ -237,6 +260,8 @@ void PointCloudUtil::FillMsg(msgs::PointCloudPacked &_msg,
       int imgIndex = imgStep + i * 3;
       if (_writeToBuffers && _xyzData)
       {
+        // Always write raw Gazebo-frame coordinates regardless of
+        // _useRosConvention; the buffer holds sensor-frame data.
         _xyzData[imgIndex + 0] = x;
         _xyzData[imgIndex + 1] = y;
         _xyzData[imgIndex + 2] = z;

--- a/src/PointCloudUtil.hh
+++ b/src/PointCloudUtil.hh
@@ -52,9 +52,13 @@ namespace gz
       /// generated the image and depth data.
       /// \param[in] _imageData RGB Image data.
       /// \param[in] _depthData Depth image data.
+      /// \param[in] _useRosConvention If true, output coordinates in the ROS
+      /// optical frame (X right, Y down, Z forward/depth). Default false uses
+      /// the Gazebo camera body frame (X forward/depth, Y left, Z up).
       public: void FillMsg(msgs::PointCloudPacked &_msg,
           const math::Angle &_hfov, const unsigned char *_imageData,
-          const float *_depthData) const;
+          const float *_depthData,
+          bool _useRosConvention = false) const;
 
       /// \brief Fill a msgs::PointCloudPacked.
       /// \param[in,out] _msg Point cloud message to fill. This message
@@ -62,8 +66,12 @@ namespace gz
       /// RgbdCameraSensor and DepthCameraSensor.
       /// \param[in] _xyzData XYZ data.
       /// \param[in] _imageData RGB data.
+      /// \param[in] _useRosConvention If true, output coordinates in the ROS
+      /// optical frame (X right, Y down, Z forward/depth). Default false uses
+      /// the Gazebo camera body frame (X forward/depth, Y left, Z up).
       public: void FillMsg(msgs::PointCloudPacked &_msg,
-          const float *_xyzData, const unsigned char *_imageData) const;
+          const float *_xyzData, const unsigned char *_imageData,
+          bool _useRosConvention = false) const;
 
       /// \brief Fill a msgs::PointCloudPacked.
       /// \param[in,out] _msg Point cloud message to fill. This message
@@ -74,11 +82,17 @@ namespace gz
       /// RGB (_imageData) and XYZ (_xyzData) buffers.
       /// \param[out] _imageData Fill _imageData wth RGB data extracted
       /// from _pointCloudData.
-      /// \param[out] _xyzData Fill _xyzData wth XYZ data extracted
-      /// from _pointCloudData.
+      /// \param[out] _xyzData Fill _xyzData with XYZ data extracted
+      /// from _pointCloudData. Always written in the Gazebo camera body frame
+      /// (X forward/depth, Y left, Z up) regardless of _useRosConvention.
+      /// \param[in] _useRosConvention If true, output coordinates in the ROS
+      /// optical frame (X right, Y down, Z forward/depth) in the message.
+      /// Default false uses the Gazebo camera body frame. Does not affect
+      /// the _xyzData write-back buffer.
       public: void FillMsg(msgs::PointCloudPacked &_msg,
           const float *_pointCloudData, bool _writeToBuffers = false,
-          unsigned char *_imageData = 0, float *_xyzData = 0) const;
+          unsigned char *_imageData = 0, float *_xyzData = 0,
+          bool _useRosConvention = false) const;
 
       /// \brief Extract RGB data from point cloud data
       /// \param[out] _imageData RGB Image buffer to be filled.

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -127,6 +127,10 @@ class gz::sensors::RgbdCameraSensor::Implementation
   /// \brief SDF Sensor DOM object.
   public: sdf::Sensor sdfSensor;
 
+  /// \brief If true, publish point cloud coordinates in the ROS optical frame
+  /// convention (X right, Y down, Z forward/depth).
+  public: bool useRosConvention = false;
+
   /// \brief The point cloud message.
   public: msgs::PointCloudPacked pointMsg;
 
@@ -194,6 +198,8 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
   }
 
   this->dataPtr->sdfSensor = _sdf;
+
+  this->dataPtr->useRosConvention = useRosConvention(_sdf);
 
   // Create the 2d image publisher
   this->dataPtr->imagePub =
@@ -582,7 +588,8 @@ bool RgbdCameraSensor::Update(const std::chrono::steady_clock::duration &_now)
         // fill point cloud msg and image data
         this->dataPtr->pointsUtil.FillMsg(this->dataPtr->pointMsg,
             this->dataPtr->pointCloudBuffer, true,
-            this->dataPtr->image.Data<unsigned char>());
+            this->dataPtr->image.Data<unsigned char>(), nullptr,
+            this->dataPtr->useRosConvention);
         filledImgData = true;
       }
 

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -161,6 +161,9 @@ class DepthCameraSensorTest: public testing::Test,
 
   // Create depth camera sensors and verify camera projection
   public: void DepthCameraProjection(const std::string &_renderEngine);
+
+  // Verify point cloud coordinates when use_ros_convention is enabled
+  public: void PointCloudRosConvention(const std::string &_renderEngine);
 };
 
 void DepthCameraSensorTest::ImagesWithBuiltinSDF(
@@ -900,6 +903,165 @@ TEST_P(DepthCameraSensorTest, CameraProjection)
 {
   gz::common::Console::SetVerbosity(2);
   DepthCameraProjection(GetParam());
+}
+
+//////////////////////////////////////////////////
+void DepthCameraSensorTest::PointCloudRosConvention(
+    const std::string &_renderEngine)
+{
+  std::string path = gz::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "depth_camera_sensor_ros_convention.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+  if ((_renderEngine.compare("ogre") != 0) &&
+      (_renderEngine.compare("ogre2") != 0))
+  {
+    GTEST_SKIP() << "Engine '" << _renderEngine
+              << "' doesn't support depth cameras" << std::endl;
+  }
+
+  auto *engine = gz::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    GTEST_SKIP() << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+  }
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene_ros_depth");
+  scene->SetAmbientLight(0.3, 0.3, 0.3);
+
+  gz::rendering::MaterialPtr blue = scene->CreateMaterial();
+  blue->SetAmbient(0.0, 0.0, 0.3);
+  blue->SetDiffuse(0.0, 0.0, 0.8);
+  blue->SetSpecular(0.5, 0.5, 0.5);
+  blue->SetShininess(50);
+  blue->SetReflectivity(0);
+
+  double unitBoxSize = 1.0;
+  gz::math::Vector3d boxPosition(3.0, 0.0, 0.0);
+  double expectedDepth = boxPosition.X() - unitBoxSize * 0.5;
+
+  gz::rendering::VisualPtr box = scene->CreateVisual();
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(boxPosition);
+  box->SetLocalRotation(0, 0, 0);
+  box->SetLocalScale(unitBoxSize, unitBoxSize, unitBoxSize);
+  box->SetMaterial(blue);
+  scene->DestroyMaterial(blue);
+  scene->RootVisual()->AddChild(box);
+
+  gz::sensors::Manager mgr;
+  gz::sensors::DepthCameraSensor *depthSensor =
+      mgr.CreateSensor<gz::sensors::DepthCameraSensor>(sensorPtr);
+  ASSERT_NE(depthSensor, nullptr);
+  depthSensor->SetScene(scene);
+
+  std::string imageTopic =
+      "/test/integration/DepthCameraPlugin_rosConvention/image";
+  std::string pointsTopic =
+      "/test/integration/DepthCameraPlugin_rosConvention/image/points";
+
+  WaitForMessageTestHelper<gz::msgs::Image> imageHelper(imageTopic);
+  WaitForMessageTestHelper<gz::msgs::PointCloudPacked>
+      pointsHelper(pointsTopic);
+  EXPECT_TRUE(depthSensor->HasConnections());
+
+  // Warmup render
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  EXPECT_TRUE(imageHelper.WaitForMessage()) << imageHelper;
+  EXPECT_TRUE(pointsHelper.WaitForMessage()) << pointsHelper;
+
+  // Point cloud header must carry the frame_id set in the SDF
+  {
+    const auto &pcMsg = pointsHelper.Message();
+    ASSERT_GT(pcMsg.header().data_size(), 0);
+    EXPECT_EQ("frame_id", pcMsg.header().data(0).key());
+    ASSERT_GT(pcMsg.header().data(0).value_size(), 0);
+    EXPECT_EQ(depthSensor->OpticalFrameId(),
+              pcMsg.header().data(0).value(0));
+  }
+
+  // Reset globals and subscribe for the measurement render
+  g_pcMutex.lock();
+  g_pcCounter = 0;
+  delete[] g_pointsXYZBuffer; g_pointsXYZBuffer = nullptr;
+  delete[] g_pointsRGBBuffer; g_pointsRGBBuffer = nullptr;
+  g_pcMutex.unlock();
+
+  gz::transport::Node node;
+  node.Subscribe(pointsTopic, &OnPointCloud);
+
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+
+  auto waitTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::duration<double>(0.001));
+  int pcCounter = 0;
+  for (int sleep = 0; sleep < 300 && pcCounter == 0; ++sleep)
+  {
+    g_pcMutex.lock();
+    pcCounter = g_pcCounter;
+    g_pcMutex.unlock();
+    std::this_thread::sleep_for(waitTime);
+  }
+  EXPECT_GT(pcCounter, 0);
+
+  g_pcMutex.lock();
+
+  int imgWidth = static_cast<int>(depthSensor->ImageWidth());
+  int imgChannelCount = 3;
+  int midWidth = imgWidth / 2;
+  int midHeight = static_cast<int>(depthSensor->ImageHeight()) / 2;
+  int imgMid = midHeight * imgWidth * imgChannelCount
+      + midWidth * imgChannelCount;
+
+  // In ROS optical frame: X=right, Y=down, Z=forward(depth)
+  float mx = g_pointsXYZBuffer[imgMid];
+  float my = g_pointsXYZBuffer[imgMid + 1];
+  float mz = g_pointsXYZBuffer[imgMid + 2];
+
+  // Center pixel: Z equals depth; X and Y are near zero (on-axis ray)
+  EXPECT_NEAR(static_cast<double>(mz), expectedDepth, DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(mx), 0.0, DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(my), 0.0, DEPTH_TOL);
+
+  // Left of center -> negative X; right of center -> positive X
+  float midLeftX  = g_pointsXYZBuffer[imgMid - imgChannelCount];
+  float midRightX = g_pointsXYZBuffer[imgMid + imgChannelCount];
+  EXPECT_LT(midLeftX,  0.0f);
+  EXPECT_GT(midRightX, 0.0f);
+
+  // Z (depth) stays constant across the same row on the flat box face
+  float midLeftZ  = g_pointsXYZBuffer[imgMid - imgChannelCount + 2];
+  float midRightZ = g_pointsXYZBuffer[imgMid + imgChannelCount + 2];
+  EXPECT_NEAR(static_cast<double>(mz), static_cast<double>(midLeftZ),
+      DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(mz), static_cast<double>(midRightZ),
+      DEPTH_TOL);
+
+  g_pcMutex.unlock();
+
+  blue.reset();
+  box.reset();
+  mgr.Remove(depthSensor->Id());
+  engine->DestroyScene(scene);
+  gz::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(DepthCameraSensorTest, PointCloudRosConvention)
+{
+  gz::common::Console::SetVerbosity(4);
+  PointCloudRosConvention(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(DepthCameraSensor, DepthCameraSensorTest,

--- a/test/integration/rgbd_camera.cc
+++ b/test/integration/rgbd_camera.cc
@@ -175,6 +175,9 @@ class RgbdCameraSensorTest: public testing::Test,
 
   // Create a Camera sensor from a SDF and gets a image message
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+
+  // Verify point cloud uses ROS optical frame convention when opted in
+  public: void PointCloudRosConvention(const std::string &_renderEngine);
 };
 
 void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
@@ -757,6 +760,168 @@ TEST_P(RgbdCameraSensorTest, ImagesWithBuiltinSDF)
 {
   common::Console::SetVerbosity(4);
   ImagesWithBuiltinSDF(GetParam());
+}
+
+//////////////////////////////////////////////////
+void RgbdCameraSensorTest::PointCloudRosConvention(
+    const std::string &_renderEngine)
+{
+  std::string path = common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "rgbd_camera_sensor_ros_convention.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+  if ((_renderEngine.compare("ogre") != 0) &&
+      (_renderEngine.compare("ogre2") != 0))
+  {
+    GTEST_SKIP() << "Engine '" << _renderEngine
+              << "' doesn't support rgbd cameras" << std::endl;
+  }
+
+  auto *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    GTEST_SKIP() << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+  }
+
+  rendering::ScenePtr scene = engine->CreateScene("scene_ros");
+  scene->SetAmbientLight(0.0, 0.0, 1.0);
+  scene->SetBackgroundColor(1.0, 0.0, 0.0);
+
+  rendering::MaterialPtr blue = scene->CreateMaterial();
+  blue->SetAmbient(0.0, 0.0, 1.0);
+  blue->SetDiffuse(0.0, 0.0, 1.0);
+  blue->SetSpecular(0.0, 0.0, 1.0);
+
+  double unitBoxSize = 1.0;
+  math::Vector3d boxPosition(3.0, 0.0, 0.0);
+  double expectedDepth = boxPosition.X() - unitBoxSize * 0.5;
+
+  rendering::VisualPtr box = scene->CreateVisual();
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(boxPosition);
+  box->SetLocalRotation(0, 0, 0);
+  box->SetLocalScale(unitBoxSize, unitBoxSize, unitBoxSize);
+  box->SetMaterial(blue);
+  scene->DestroyMaterial(blue);
+  scene->RootVisual()->AddChild(box);
+
+  sensors::Manager mgr;
+  sensors::RgbdCameraSensor *rgbdSensor =
+      mgr.CreateSensor<sensors::RgbdCameraSensor>(sensorPtr);
+  ASSERT_NE(rgbdSensor, nullptr);
+  rgbdSensor->SetScene(scene);
+
+  std::string pointsTopic =
+    "/test/integration/RgbdCameraPlugin_rosConvention/points";
+  WaitForMessageTestHelper<msgs::PointCloudPacked>
+      pointsHelper(pointsTopic);
+
+  // Wait for the transport layer to propagate the subscription so the sensor
+  // detects HasPointConnections() and doesn't skip rendering.
+  {
+    auto waitTime = std::chrono::milliseconds(1);
+    for (int sleep = 0; sleep < 300 && !rgbdSensor->HasPointConnections();
+        ++sleep)
+      std::this_thread::sleep_for(waitTime);
+  }
+  EXPECT_TRUE(rgbdSensor->HasPointConnections());
+
+  // First render to warm up the sensor
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+  EXPECT_TRUE(pointsHelper.WaitForMessage()) << pointsHelper;
+
+  // Point cloud header must carry the frame_id set in the SDF
+  {
+    const auto &pcMsg = pointsHelper.Message();
+    ASSERT_GT(pcMsg.header().data_size(), 0);
+    EXPECT_EQ("frame_id", pcMsg.header().data(0).key());
+    ASSERT_GT(pcMsg.header().data(0).value_size(), 0);
+    EXPECT_EQ(rgbdSensor->OpticalFrameId(), pcMsg.header().data(0).value(0));
+  }
+
+  // Reset global point cloud buffers so we get a fresh capture
+  g_pcMutex.lock();
+  g_pcCounter = 0;
+  delete[] g_pointsXYZBuffer; g_pointsXYZBuffer = nullptr;
+  delete[] g_pointsRGBBuffer; g_pointsRGBBuffer = nullptr;
+  g_pcMutex.unlock();
+
+  transport::Node node;
+  node.Subscribe(pointsTopic, &OnPointCloud);
+
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+
+  auto waitTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::duration<double>(0.001));
+  int pcCounter = 0;
+  for (int sleep = 0; sleep < 300 && pcCounter == 0; ++sleep)
+  {
+    g_pcMutex.lock();
+    pcCounter = g_pcCounter;
+    g_pcMutex.unlock();
+    std::this_thread::sleep_for(waitTime);
+  }
+  EXPECT_GT(pcCounter, 0);
+
+  g_pcMutex.lock();
+
+  int imgWidth = static_cast<int>(rgbdSensor->ImageWidth());
+  int imgChannelCount = 3;
+  int midWidth = imgWidth / 2;
+  int midHeight = static_cast<int>(rgbdSensor->ImageHeight()) / 2;
+  int imgMid = midHeight * imgWidth * imgChannelCount
+      + midWidth * imgChannelCount;
+
+  // In ROS optical frame: X=right, Y=down, Z=forward(depth)
+  float mx = g_pointsXYZBuffer[imgMid];
+  float my = g_pointsXYZBuffer[imgMid + 1];
+  float mz = g_pointsXYZBuffer[imgMid + 2];
+
+  // Center pixel: Z equals depth; X and Y are near zero (on-axis ray)
+  EXPECT_NEAR(static_cast<double>(mz), expectedDepth, DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(mx), 0.0, DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(my), 0.0, DEPTH_TOL);
+
+  // Left of center -> negative X; right of center -> positive X
+  float midLeftX  = g_pointsXYZBuffer[imgMid - imgChannelCount];
+  float midRightX = g_pointsXYZBuffer[imgMid + imgChannelCount];
+  EXPECT_LT(midLeftX,  0.0f);
+  EXPECT_GT(midRightX, 0.0f);
+
+  // Z (depth) stays constant across the same row on the flat box face
+  float midLeftZ  = g_pointsXYZBuffer[imgMid - imgChannelCount + 2];
+  float midRightZ = g_pointsXYZBuffer[imgMid + imgChannelCount + 2];
+  EXPECT_NEAR(static_cast<double>(mz), static_cast<double>(midLeftZ),
+      DEPTH_TOL);
+  EXPECT_NEAR(static_cast<double>(mz), static_cast<double>(midRightZ),
+      DEPTH_TOL);
+
+  g_pcMutex.unlock();
+
+  box.reset();
+  mgr.Remove(rgbdSensor->Id());
+  engine->DestroyScene(scene);
+  scene.reset();
+  blue.reset();
+  rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(RgbdCameraSensorTest, PointCloudRosConvention)
+{
+  common::Console::SetVerbosity(4);
+  PointCloudRosConvention(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(RgbdCameraSensor, RgbdCameraSensorTest,

--- a/test/sdf/depth_camera_sensor_ros_convention.sdf
+++ b/test/sdf/depth_camera_sensor_ros_convention.sdf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<sdf version="1.6" xmlns:gz="http://gazebosim.org/schema">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera1" type="depth_camera">
+        <update_rate>10</update_rate>
+        <topic>/test/integration/DepthCameraPlugin_rosConvention/image</topic>
+        <frame_id>camera1_optical_link</frame_id>
+        <camera>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>257</width>
+            <height>257</height>
+            <format>R_FLOAT32</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+          <gz:use_ros_convention>true</gz:use_ros_convention>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/sdf/rgbd_camera_sensor_ros_convention.sdf
+++ b/test/sdf/rgbd_camera_sensor_ros_convention.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<sdf version="1.6" xmlns:gz="http://gazebosim.org/schema">
+  <model name="m1">
+    <link name="link1">
+      <sensor name="camera1" type="rgbd_camera">
+        <update_rate>10</update_rate>
+        <topic>/test/integration/RgbdCameraPlugin_rosConvention</topic>
+        <frame_id>camera1_optical_link</frame_id>
+        <camera>
+          <horizontal_fov>1.05</horizontal_fov>
+          <image>
+            <width>257</width>
+            <height>257</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10.0</far>
+          </clip>
+          <gz:use_ros_convention>true</gz:use_ros_convention>
+        </camera>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #29
Fixes #545 

This adds a new `<gz:useRosConvention>` tag to URDF/SDF files that allows overriding the point cloud orientation. When the flag is set true, the point cloud is rotated to match the expected coordinate frame convention in ROS (X right, Y down, Z forward / depth):

<img width="1385" height="1039" alt="image" src="https://github.com/user-attachments/assets/5cd5c300-0a92-4810-83cd-059132aca3ff" />


Since the issue has been up for a couple of years, I maintained backwards compatibility when `<gz:useRosConvention>` is either set to false or unset (X forward / depth, Y left, Z up):

<img width="1385" height="1039" alt="image" src="https://github.com/user-attachments/assets/767ff5c9-802e-4d09-b648-0cd4084d96f0" />


Snippet how this integrates into URDF:
```
    <gazebo reference="${name}_link">
      <sensor name="${name}" type="rgbd_camera">
        <gz_frame_id>${name}_optical_link</gz_frame_id>
        <camera name="${name}">
          <gz:use_ros_convention>true</gz:use_ros_convention>
          <...>
        </camera>
      </sensor>
    </gazebo>
```

I'm not sure if this is the best solution, but I am also not very familiar with URDF/SDF nuances. Consider this perhaps a suggestions, I'm happy to move this around or rename if required.


## Backport Policy
I would like to see this backported to older releases. Because some code structure changes, it's not 1:1 compatible, but the logic is transferable. I have a version of this that is compatible with Harmonic locally I could submit. 
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.
I wrote the code myself, but had Claude write the docstrings, review my changes and discussed integration into URDF / SDF.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
