### PR TITLE
[bazel] Fix macos build by adding gz-utils//:ImplPtr dep

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -139,7 +139,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -156,7 +156,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -173,7 +173,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -195,6 +195,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -221,7 +222,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -254,7 +255,6 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
         "@gz-utils//:ImplPtr",
-        "@gz-utils//:SuppressWarning",
         "@sdformat",
     ],
 )
@@ -281,7 +281,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -304,6 +304,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
+        "@gz-utils//:ImplPtr",
     ],
 )
 
@@ -320,7 +321,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -341,7 +342,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -359,7 +360,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -393,6 +394,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
+        "@gz-utils//:ImplPtr",
         "@gz-utils//:SuppressWarning",
         "@sdformat",
     ],
@@ -425,7 +427,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -443,7 +445,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -461,7 +463,7 @@ gz_sensor_library(
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -492,6 +494,7 @@ gz_sensor_library(
         "@gz-common//events",
         "@gz-common//profiler",
         "@gz-rendering",
+        "@gz-utils//:ImplPtr",
         "@gz-utils//:SuppressWarning",
         "@sdformat",
     ],
@@ -520,7 +523,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -543,7 +546,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -567,7 +570,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )
@@ -591,7 +594,7 @@ gz_sensor_library(
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-rendering",
         "@gz-transport",
-        "@gz-utils//:SuppressWarning",
+        "@gz-utils//:ImplPtr",
         "@sdformat",
     ],
 )


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes bazel build on macos, which was broken with https://github.com/gazebosim/gz-sensors/pull/623.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.5 Flash in Antigravity

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.