### PR TITLE
Backport CpuLidarSensor (#593) to gz-sensors10

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -240,6 +240,24 @@ cc_test(
 )
 
 gz_sensor_library(
+    name = "cpu_lidar",
+    srcs = ["src/CpuLidarSensor.cc"],
+    hdrs = ["include/gz/sensors/CpuLidarSensor.hh"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sensors",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-transport",
+        "@gz-utils//:SuppressWarning",
+        "@sdformat",
+    ],
+)
+
+gz_sensor_library(
     name = "depth_camera",
     srcs = ["src/DepthCameraSensor.cc"],
     hdrs = ["include/gz/sensors/DepthCameraSensor.hh"],
@@ -595,6 +613,7 @@ cc_library(
         ":altimeter",
         ":boundingbox_camera",
         ":camera",
+        ":cpu_lidar",
         ":depth_camera",
         ":dvl",
         ":force_torque",

--- a/include/gz/sensors/CpuLidarSensor.hh
+++ b/include/gz/sensors/CpuLidarSensor.hh
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_SENSORS_CPULIDARSENSOR_HH_
+#define GZ_SENSORS_CPULIDARSENSOR_HH_
+
+#include <utility>
+#include <vector>
+
+#include <sdf/Element.hh>
+#include <sdf/Sensor.hh>
+
+#include <gz/math/Angle.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/utils/ImplPtr.hh>
+
+#include <gz/sensors/config.hh>
+#include <gz/sensors/cpu_lidar/Export.hh>
+
+#include "gz/sensors/Sensor.hh"
+
+namespace gz
+{
+  namespace sensors
+  {
+    inline namespace GZ_SENSORS_VERSION_NAMESPACE {
+
+    /// \brief CPU-based lidar sensor that performs ray casting without
+    /// depending on gz-rendering.
+    class GZ_SENSORS_CPU_LIDAR_VISIBLE CpuLidarSensor : public Sensor
+    {
+      /// \brief Result of a single ray cast
+      public: struct RayResult
+      {
+        /// \brief Hit point in entity frame
+        gz::math::Vector3d point;
+
+        /// \brief Fraction along the ray [0,1]; +INF if no object in range;
+        /// NaN on error.
+        double fraction;
+
+        /// \brief Normal at hit point in entity frame
+        gz::math::Vector3d normal;
+
+        /// \brief Intensity value
+        double intensity = 0.0;
+      };
+      /// \brief constructor
+      public: CpuLidarSensor();
+
+      /// \brief destructor
+      public: virtual ~CpuLidarSensor();
+
+      /// \brief Load the sensor based on data from an sdf::Sensor object.
+      /// \param[in] _sdf SDF Sensor parameters.
+      /// \return true if loading was successful
+      public: virtual bool Load(const sdf::Sensor &_sdf) override;
+
+      /// \brief Load the sensor with SDF parameters.
+      /// \param[in] _sdf SDF Sensor parameters.
+      /// \return true if loading was successful
+      public: virtual bool Load(sdf::ElementPtr _sdf) override;
+
+      using Sensor::Update;
+
+      /// \brief Update the sensor and generate data
+      /// \param[in] _now The current time
+      /// \return true if the update was successful
+      public: virtual bool Update(
+        const std::chrono::steady_clock::duration &_now) override;
+
+      /// \brief Check if there are any subscribers
+      /// \return True if there are subscribers, false otherwise
+      public: virtual bool HasConnections() const override;
+
+      /// \brief Get the minimum horizontal angle
+      public: gz::math::Angle AngleMin() const;
+
+      /// \brief Get the maximum horizontal angle
+      public: gz::math::Angle AngleMax() const;
+
+      /// \brief Get the minimum vertical angle
+      public: gz::math::Angle VerticalAngleMin() const;
+
+      /// \brief Get the maximum vertical angle
+      public: gz::math::Angle VerticalAngleMax() const;
+
+      /// \brief Get the minimum range
+      public: double RangeMin() const;
+
+      /// \brief Get the maximum range
+      public: double RangeMax() const;
+
+      /// \brief Get the horizontal ray count
+      public: unsigned int RayCount() const;
+
+      /// \brief Get the vertical ray count
+      public: unsigned int VerticalRayCount() const;
+
+      /// \brief Generate rays from the lidar configuration.
+      /// \return Vector of (start, end) pairs in entity frame
+      public: std::vector<std::pair<gz::math::Vector3d, gz::math::Vector3d>>
+        GenerateRays() const;
+
+      /// \brief Set the raycast results from the physics engine.
+      /// \param[in] _results Vector of results, one per ray.
+      public: void SetRaycastResults(
+        const std::vector<RayResult> &_results);
+
+      /// \brief Get all range values.
+      /// \param[out] _ranges Vector to fill with range data.
+      public: void Ranges(std::vector<double> &_ranges) const;
+
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+    };
+    }
+  }
+}
+
+#endif

--- a/include/gz/sensors/CpuLidarSensor.hh
+++ b/include/gz/sensors/CpuLidarSensor.hh
@@ -50,7 +50,7 @@ namespace gz
 
         /// \brief Fraction along the ray [0,1]; non-finite if no object in
         /// range: NaN on gz-physics9, +INF on gz-physics10 (REP-117). Misses
-        /// are detected with !std::isfinite, which covers both.
+        /// are detected with `!std::isfinite`, which covers both.
         double fraction;
 
         /// \brief Normal at hit point in entity frame

--- a/include/gz/sensors/CpuLidarSensor.hh
+++ b/include/gz/sensors/CpuLidarSensor.hh
@@ -48,8 +48,9 @@ namespace gz
         /// \brief Hit point in entity frame
         gz::math::Vector3d point;
 
-        /// \brief Fraction along the ray [0,1]; +INF if no object in range;
-        /// NaN on error.
+        /// \brief Fraction along the ray [0,1]; non-finite if no object in
+        /// range: NaN on gz-physics9, +INF on gz-physics10 (REP-117). Misses
+        /// are detected with !std::isfinite, which covers both.
         double fraction;
 
         /// \brief Normal at hit point in entity frame

--- a/include/gz/sensors/CpuLidarSensor.hh
+++ b/include/gz/sensors/CpuLidarSensor.hh
@@ -50,7 +50,7 @@ namespace gz
 
         /// \brief Fraction along the ray [0,1]; non-finite if no object in
         /// range: NaN on gz-physics9, +INF on gz-physics10 (REP-117). Misses
-        /// are detected with `!std::isfinite`, which covers both.
+        /// are detected with !std::%isfinite, which covers both.
         double fraction;
 
         /// \brief Normal at hit point in entity frame

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,14 @@ gz_add_component(magnetometer SOURCES ${magnetometer_sources} GET_TARGET_NAME ma
 set(imu_sources ImuSensor.cc)
 gz_add_component(imu SOURCES ${imu_sources} GET_TARGET_NAME imu_target)
 
+set(cpu_lidar_sources CpuLidarSensor.cc)
+gz_add_component(cpu_lidar SOURCES ${cpu_lidar_sources} GET_TARGET_NAME cpu_lidar_target)
+target_link_libraries(${cpu_lidar_target}
+  PRIVATE
+    gz-msgs::gz-msgs
+    gz-transport::gz-transport
+)
+
 set(altimeter_sources AltimeterSensor.cc)
 gz_add_component(altimeter SOURCES ${altimeter_sources} GET_TARGET_NAME altimeter_target)
 

--- a/src/CpuLidarSensor.cc
+++ b/src/CpuLidarSensor.cc
@@ -1,0 +1,483 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cmath>
+#include <limits>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include <gz/common/Console.hh>
+#include <gz/common/Profiler.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/msgs/laserscan.pb.h>
+#include <gz/math/Vector3.hh>
+#include <gz/msgs/pointcloud_packed.pb.h>
+#include <gz/msgs/PointCloudPackedUtils.hh>
+#include <gz/msgs/Utility.hh>
+#include <gz/transport/Node.hh>
+
+#include <sdf/Lidar.hh>
+
+#include <gz/utils/ImplPtr.hh>
+
+#include "gz/sensors/CpuLidarSensor.hh"
+#include "gz/sensors/GaussianNoiseModel.hh"
+#include "gz/sensors/Noise.hh"
+#include "gz/sensors/SensorFactory.hh"
+#include "gz/sensors/SensorTypes.hh"
+
+using namespace gz;
+using namespace sensors;
+
+class gz::sensors::CpuLidarSensor::Implementation
+{
+  /// \brief true if Load() has been called and was successful
+  public: bool initialized = false;
+
+  /// \brief SDF lidar config
+  public: sdf::Lidar sdfLidar;
+
+  /// \brief Computed range values from the latest raycast results
+  public: std::vector<double> ranges;
+
+  /// \brief Computed intensity values from the latest raycast results
+  public: std::vector<double> intensities;
+
+  /// \brief Transport node
+  public: transport::Node node;
+
+  /// \brief LaserScan publisher
+  public: transport::Node::Publisher scanPub;
+
+  /// \brief LaserScan message (reused)
+  public: msgs::LaserScan laserMsg;
+
+  /// \brief Noise model for lidar data
+  public: std::unordered_map<gz::sensors::SensorNoiseType,
+      gz::sensors::NoisePtr> noises;
+
+  /// \brief PointCloud publisher
+  public: transport::Node::Publisher pointPub;
+
+  /// \brief PointCloud message (reused)
+  public: msgs::PointCloudPacked pointMsg;
+
+  /// \brief Pre-computed unit vectors for each ray.
+  public: std::vector<gz::math::Vector3d> unitVectors;
+};
+
+//////////////////////////////////////////////////
+CpuLidarSensor::CpuLidarSensor()
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
+{
+}
+
+//////////////////////////////////////////////////
+CpuLidarSensor::~CpuLidarSensor() = default;
+
+//////////////////////////////////////////////////
+bool CpuLidarSensor::Load(const sdf::Sensor &_sdf)
+{
+  if (!Sensor::Load(_sdf))
+    return false;
+
+  if (_sdf.Type() != sdf::SensorType::LIDAR)
+  {
+    gzerr << "Attempting to load a CpuLidar sensor, but received "
+      << "a " << _sdf.TypeStr() << std::endl;
+    return false;
+  }
+
+  if (_sdf.LidarSensor() == nullptr)
+  {
+    gzerr << "Attempting to load a CpuLidar sensor, but received "
+      << "a null lidar sensor." << std::endl;
+    return false;
+  }
+
+  this->dataPtr->sdfLidar = *_sdf.LidarSensor();
+
+  const std::map<SensorNoiseType, sdf::Noise> noises = {
+    {LIDAR_NOISE, this->dataPtr->sdfLidar.LidarNoise()},
+  };
+
+  for (const auto & [noiseType, noiseSdf] : noises)
+  {
+    if (noiseSdf.Type() == sdf::NoiseType::GAUSSIAN)
+    {
+      if (!math::equal(noiseSdf.Mean(), 0.0) ||
+          !math::equal(noiseSdf.StdDev(), 0.0) ||
+          !math::equal(noiseSdf.BiasMean(), 0.0) ||
+          !math::equal(noiseSdf.DynamicBiasStdDev(), 0.0) ||
+          !math::equal(noiseSdf.DynamicBiasCorrelationTime(), 0.0))
+      {
+        this->dataPtr->noises[noiseType] =
+          NoiseFactory::NewNoiseModel(noiseSdf);
+      }
+    }
+    else if (noiseSdf.Type() != sdf::NoiseType::NONE)
+    {
+      gzwarn << "The cpu lidar sensor only supports Gaussian noise. "
+       << "The supplied noise type[" << static_cast<int>(noiseSdf.Type())
+       << "] is not supported." << std::endl;
+    }
+  }
+
+  if (this->Topic().empty())
+    this->SetTopic("/lidar");
+
+  this->dataPtr->scanPub =
+      this->dataPtr->node.Advertise<gz::msgs::LaserScan>(this->Topic());
+  if (!this->dataPtr->scanPub)
+  {
+    gzerr << "Unable to create publisher on topic["
+      << this->Topic() << "].\n";
+    return false;
+  }
+
+  const unsigned int hSamples = this->RayCount();
+  const unsigned int vSamples = this->VerticalRayCount();
+  if (hSamples == 0 || vSamples == 0)
+  {
+    gzerr << "CpuLidarSensor: ray count is 0, cannot configure sensor.\n";
+    return false;
+  }
+  const double hMin = this->AngleMin().Radian();
+  const double hMax = this->AngleMax().Radian();
+  const double vMin = this->VerticalAngleMin().Radian();
+  const double vMax = this->VerticalAngleMax().Radian();
+  const double hStep = hSamples > 1 ? (hMax - hMin) / (hSamples - 1) : 0.0;
+  const double vStep = vSamples > 1 ? (vMax - vMin) / (vSamples - 1) : 0.0;
+
+  auto &msg = this->dataPtr->laserMsg;
+  msg.set_count(hSamples);
+  msg.set_range_min(this->RangeMin());
+  msg.set_range_max(this->RangeMax());
+  msg.set_angle_min(hMin);
+  msg.set_angle_max(hMax);
+  msg.set_angle_step(hStep);
+  msg.set_vertical_angle_min(vMin);
+  msg.set_vertical_angle_max(vMax);
+  msg.set_vertical_angle_step(vStep);
+  msg.set_vertical_count(vSamples);
+
+  msgs::InitPointCloudPacked(this->dataPtr->pointMsg, this->FrameId(), false,
+      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
+      {"intensity", msgs::PointCloudPacked::Field::FLOAT32},
+      {"ring", msgs::PointCloudPacked::Field::UINT16}});
+
+  this->dataPtr->pointMsg.set_width(hSamples);
+  this->dataPtr->pointMsg.set_height(vSamples);
+  this->dataPtr->pointMsg.set_row_step(
+      this->dataPtr->pointMsg.point_step() *
+      this->dataPtr->pointMsg.width());
+
+  this->dataPtr->pointPub =
+      this->dataPtr->node.Advertise<gz::msgs::PointCloudPacked>(
+          this->Topic() + "/points");
+  if (!this->dataPtr->pointPub)
+  {
+    gzerr << "Unable to create publisher on topic["
+      << this->Topic() << "/points].\n";
+    return false;
+  }
+
+  // Pre-compute unit vectors for each ray
+
+  this->dataPtr->unitVectors.clear();
+  this->dataPtr->unitVectors.reserve(hSamples * vSamples);
+  for (unsigned int v = 0; v < vSamples; ++v)
+  {
+    const double inclination = vMin + v * vStep;
+    for (unsigned int h = 0; h < hSamples; ++h)
+    {
+      const double azimuth = hMin + h * hStep;
+      this->dataPtr->unitVectors.emplace_back(
+        std::cos(inclination) * std::cos(azimuth),
+        std::cos(inclination) * std::sin(azimuth),
+        std::sin(inclination));
+    }
+  }
+
+  this->dataPtr->initialized = true;
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool CpuLidarSensor::Load(sdf::ElementPtr _sdf)
+{
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(_sdf);
+  return this->Load(sdfSensor);
+}
+
+//////////////////////////////////////////////////
+bool CpuLidarSensor::Update(
+    const std::chrono::steady_clock::duration &_now)
+{
+  GZ_PROFILE("CpuLidarSensor::Update");
+  if (!this->dataPtr->initialized)
+  {
+    gzerr << "Not initialized, update ignored.\n";
+    return false;
+  }
+
+  if (!this->HasConnections())
+    return false;
+
+  const unsigned int totalRays = this->RayCount() * this->VerticalRayCount();
+  if (this->dataPtr->ranges.size() != totalRays)
+    return false;
+
+  if (this->dataPtr->scanPub.HasConnections())
+  {
+    auto &msg = this->dataPtr->laserMsg;
+
+    *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
+    msg.mutable_header()->clear_data();
+    auto frame = msg.mutable_header()->add_data();
+    frame->set_key("frame_id");
+    frame->add_value(this->FrameId());
+    msg.set_frame(this->FrameId());
+
+    msgs::Set(msg.mutable_world_pose(), this->Pose());
+
+    const unsigned int hCount = this->RayCount();
+    const unsigned int vCount = this->VerticalRayCount();
+    const unsigned int totalCount = hCount * vCount;
+
+    if (msg.ranges_size() != static_cast<int>(totalCount))
+    {
+      msg.clear_ranges();
+      msg.clear_intensities();
+      msg.set_count(hCount);
+      msg.set_vertical_count(vCount);
+      for (unsigned int i = 0; i < totalCount; ++i)
+      {
+        msg.add_ranges(gz::math::NAN_F);
+        msg.add_intensities(0.0);
+      }
+    }
+
+    for (unsigned int i = 0; i < totalCount; ++i)
+    {
+      const double intensity =
+        i < this->dataPtr->intensities.size() ?
+        this->dataPtr->intensities[i] : 0.0;
+      msg.set_ranges(static_cast<int>(i), this->dataPtr->ranges[i]);
+      msg.set_intensities(static_cast<int>(i), intensity);
+    }
+
+    this->AddSequence(msg.mutable_header());
+    this->dataPtr->scanPub.Publish(msg);
+  }
+
+  if (this->dataPtr->pointPub.HasConnections())
+  {
+    *this->dataPtr->pointMsg.mutable_header()->mutable_stamp() =
+      msgs::Convert(_now);
+    this->dataPtr->pointMsg.mutable_header()->clear_data();
+    auto pcFrame = this->dataPtr->pointMsg.mutable_header()->add_data();
+    pcFrame->set_key("frame_id");
+    pcFrame->add_value(this->FrameId());
+
+    const unsigned int hSamples = this->RayCount();
+    const unsigned int vSamples = this->VerticalRayCount();
+
+    std::string *msgBuffer = this->dataPtr->pointMsg.mutable_data();
+    msgBuffer->resize(this->dataPtr->pointMsg.row_step() *
+        this->dataPtr->pointMsg.height());
+    char *msgBufferIndex = msgBuffer->data();
+    bool isDense = true;
+
+    for (unsigned int j = 0; j < vSamples; ++j)
+    {
+      for (unsigned int i = 0; i < hSamples; ++i)
+      {
+        const int index = j * hSamples + i;
+        const double range = this->dataPtr->ranges[index];
+
+        if (isDense)
+          isDense = !(std::isnan(range) || std::isinf(range));
+
+        gz::math::Vector3d p = this->dataPtr->unitVectors[index] * range;
+
+        int fieldIndex = 0;
+
+        *reinterpret_cast<float *>(msgBufferIndex +
+            this->dataPtr->pointMsg.field(fieldIndex++).offset()) =
+          static_cast<float>(p.X());
+
+        *reinterpret_cast<float *>(msgBufferIndex +
+            this->dataPtr->pointMsg.field(fieldIndex++).offset()) =
+          static_cast<float>(p.Y());
+
+        *reinterpret_cast<float *>(msgBufferIndex +
+            this->dataPtr->pointMsg.field(fieldIndex++).offset()) =
+          static_cast<float>(p.Z());
+
+        *reinterpret_cast<float *>(msgBufferIndex +
+            this->dataPtr->pointMsg.field(fieldIndex++).offset()) =
+          static_cast<float>(
+            index < static_cast<int>(this->dataPtr->intensities.size()) ?
+            this->dataPtr->intensities[index] : 0.0);
+
+        *reinterpret_cast<uint16_t *>(msgBufferIndex +
+            this->dataPtr->pointMsg.field(fieldIndex++).offset()) =
+          static_cast<uint16_t>(j);
+
+        msgBufferIndex += this->dataPtr->pointMsg.point_step();
+      }
+    }
+    this->dataPtr->pointMsg.set_is_dense(isDense);
+
+    this->AddSequence(this->dataPtr->pointMsg.mutable_header());
+    this->dataPtr->pointPub.Publish(this->dataPtr->pointMsg);
+  }
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool CpuLidarSensor::HasConnections() const
+{
+  return (this->dataPtr->scanPub &&
+         this->dataPtr->scanPub.HasConnections()) ||
+         (this->dataPtr->pointPub &&
+         this->dataPtr->pointPub.HasConnections());
+}
+
+//////////////////////////////////////////////////
+gz::math::Angle CpuLidarSensor::AngleMin() const
+{
+  return this->dataPtr->sdfLidar.HorizontalScanMinAngle();
+}
+
+//////////////////////////////////////////////////
+gz::math::Angle CpuLidarSensor::AngleMax() const
+{
+  return this->dataPtr->sdfLidar.HorizontalScanMaxAngle();
+}
+
+//////////////////////////////////////////////////
+gz::math::Angle CpuLidarSensor::VerticalAngleMin() const
+{
+  return this->dataPtr->sdfLidar.VerticalScanMinAngle();
+}
+
+//////////////////////////////////////////////////
+gz::math::Angle CpuLidarSensor::VerticalAngleMax() const
+{
+  return this->dataPtr->sdfLidar.VerticalScanMaxAngle();
+}
+
+//////////////////////////////////////////////////
+double CpuLidarSensor::RangeMin() const
+{
+  return this->dataPtr->sdfLidar.RangeMin();
+}
+
+//////////////////////////////////////////////////
+double CpuLidarSensor::RangeMax() const
+{
+  return this->dataPtr->sdfLidar.RangeMax();
+}
+
+//////////////////////////////////////////////////
+unsigned int CpuLidarSensor::RayCount() const
+{
+  return this->dataPtr->sdfLidar.HorizontalScanSamples();
+}
+
+//////////////////////////////////////////////////
+unsigned int CpuLidarSensor::VerticalRayCount() const
+{
+  return this->dataPtr->sdfLidar.VerticalScanSamples();
+}
+
+//////////////////////////////////////////////////
+std::vector<std::pair<gz::math::Vector3d, gz::math::Vector3d>>
+CpuLidarSensor::GenerateRays() const
+{
+  const unsigned int hSamples = this->RayCount();
+  const unsigned int vSamples = this->VerticalRayCount();
+  const double rMin = this->RangeMin();
+  const double rMax = this->RangeMax();
+
+  std::vector<std::pair<gz::math::Vector3d, gz::math::Vector3d>> rays;
+  rays.reserve(hSamples * vSamples);
+
+  for (const auto &unitVec : this->dataPtr->unitVectors)
+  {
+    rays.emplace_back(unitVec * rMin, unitVec * rMax);
+  }
+
+  return rays;
+}
+
+//////////////////////////////////////////////////
+void CpuLidarSensor::SetRaycastResults(
+    const std::vector<RayResult> &_results)
+{
+  const double rMin = this->RangeMin();
+  const double rMax = this->RangeMax();
+  const double rayLength = rMax - rMin;
+
+  this->dataPtr->ranges.resize(_results.size());
+  this->dataPtr->intensities.resize(_results.size());
+
+  for (size_t i = 0; i < _results.size(); ++i)
+  {
+    this->dataPtr->intensities[i] = _results[i].intensity;
+    if (std::isinf(_results[i].fraction))
+    {
+      this->dataPtr->ranges[i] =
+        std::numeric_limits<double>::infinity();
+    }
+    else
+    {
+      double range = rMin + _results[i].fraction * rayLength;
+      if (range < rMin)
+        range = -std::numeric_limits<double>::infinity();
+      else if (range > rMax)
+        range = std::numeric_limits<double>::infinity();
+      this->dataPtr->ranges[i] = range;
+    }
+  }
+
+  if (this->dataPtr->noises.find(LIDAR_NOISE) != this->dataPtr->noises.end())
+  {
+    for (size_t i = 0; i < this->dataPtr->ranges.size(); ++i)
+    {
+      if (std::isfinite(this->dataPtr->ranges[i]))
+      {
+        this->dataPtr->ranges[i] =
+          this->dataPtr->noises[LIDAR_NOISE]->Apply(this->dataPtr->ranges[i]);
+
+        this->dataPtr->ranges[i] = gz::math::clamp(this->dataPtr->ranges[i],
+            this->RangeMin(), this->RangeMax());
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void CpuLidarSensor::Ranges(std::vector<double> &_ranges) const
+{
+  _ranges = this->dataPtr->ranges;
+}

--- a/src/CpuLidarSensor.cc
+++ b/src/CpuLidarSensor.cc
@@ -444,7 +444,9 @@ void CpuLidarSensor::SetRaycastResults(
   for (size_t i = 0; i < _results.size(); ++i)
   {
     this->dataPtr->intensities[i] = _results[i].intensity;
-    if (std::isinf(_results[i].fraction))
+    // A miss is NaN on gz-physics9 and +INF on gz-physics10; !isfinite covers
+    // both. (Mirrors RayIntersectionT::IsHit().)
+    if (!std::isfinite(_results[i].fraction))
     {
       this->dataPtr->ranges[i] =
         std::numeric_limits<double>::infinity();

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tests
   air_pressure.cc
   air_speed.cc
   altimeter.cc
+  cpu_lidar_sensor.cc
   force_torque.cc
   imu.cc
   logical_camera.cc
@@ -63,6 +64,7 @@ gz_build_tests(TYPE INTEGRATION
     ${PROJECT_LIBRARY_TARGET_NAME}-air_pressure
     ${PROJECT_LIBRARY_TARGET_NAME}-air_speed
     ${PROJECT_LIBRARY_TARGET_NAME}-altimeter
+    ${PROJECT_LIBRARY_TARGET_NAME}-cpu_lidar
     ${PROJECT_LIBRARY_TARGET_NAME}-force_torque
     ${PROJECT_LIBRARY_TARGET_NAME}-imu
     ${PROJECT_LIBRARY_TARGET_NAME}-logical_camera

--- a/test/integration/cpu_lidar_sensor.cc
+++ b/test/integration/cpu_lidar_sensor.cc
@@ -1,0 +1,615 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <sdf/Element.hh>
+#include <sdf/parser.hh>
+
+#include <gz/msgs/laserscan.pb.h>
+#include <gz/msgs/pointcloud_packed.pb.h>
+
+#include <gz/common/Console.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Rand.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/sensors/CpuLidarSensor.hh>
+#include <gz/sensors/SensorFactory.hh>
+#include <gz/transport/Node.hh>
+
+#include "test_config.hh"  // NOLINT(build/include)
+#include "TransportTestTools.hh"
+
+/// \brief Helper function to create a cpu lidar sdf element.
+/// Optionally include a Gaussian noise element by passing a non-empty
+/// _noiseType (e.g. "gaussian").
+sdf::ElementPtr CpuLidarToSdf(const std::string &_name,
+    const gz::math::Pose3d &_pose, const double _updateRate,
+    const std::string &_topic, const double _horzSamples,
+    const double _horzMinAngle, const double _horzMaxAngle,
+    const double _vertSamples, const double _vertMinAngle,
+    const double _vertMaxAngle, const double _rangeMin,
+    const double _rangeMax, const bool _alwaysOn,
+    const bool _visualize,
+    const double _horzResolution = 1.0,
+    const double _vertResolution = 1.0,
+    const std::string &_noiseType = "",
+    const double _noiseMean = 0.0,
+    const double _noiseStdDev = 0.0)
+{
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='" << _name << "' type='lidar'>"
+    << "      <pose>" << _pose << "</pose>"
+    << "      <topic>" << _topic << "</topic>"
+    << "      <update_rate>" << _updateRate << "</update_rate>"
+    << "      <ray>"
+    << "        <scan>"
+    << "          <horizontal>"
+    << "            <samples>" << _horzSamples << "</samples>"
+    << "            <resolution>" << _horzResolution << "</resolution>"
+    << "            <min_angle>" << _horzMinAngle << "</min_angle>"
+    << "            <max_angle>" << _horzMaxAngle << "</max_angle>"
+    << "          </horizontal>"
+    << "          <vertical>"
+    << "            <samples>" << _vertSamples << "</samples>"
+    << "            <resolution>" << _vertResolution << "</resolution>"
+    << "            <min_angle>" << _vertMinAngle << "</min_angle>"
+    << "            <max_angle>" << _vertMaxAngle << "</max_angle>"
+    << "          </vertical>"
+    << "        </scan>"
+    << "        <range>"
+    << "          <min>" << _rangeMin << "</min>"
+    << "          <max>" << _rangeMax << "</max>"
+    << "          <resolution>0.01</resolution>"
+    << "        </range>";
+  if (!_noiseType.empty())
+  {
+    stream
+      << "        <noise>"
+      << "          <type>" << _noiseType << "</type>"
+      << "          <mean>" << _noiseMean << "</mean>"
+      << "          <stddev>" << _noiseStdDev << "</stddev>"
+      << "        </noise>";
+  }
+  stream
+    << "      </ray>"
+    << "      <alwaysOn>" << _alwaysOn << "</alwaysOn>"
+    << "      <visualize>" << _visualize << "</visualize>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed))
+    return sdf::ElementPtr();
+
+  return sdfParsed->Root()->GetElement("model")->GetElement("link")
+    ->GetElement("sensor");
+}
+
+/// \brief Test CPU Lidar sensor
+class CpuLidarSensorTest : public testing::Test
+{
+  protected: void SetUp() override
+  {
+    gz::common::Console::SetVerbosity(4);
+  }
+};
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, CreateSensor)
+{
+  const std::string name = "TestCpuLidar";
+  const std::string topic = "/gz/sensors/test/cpu_lidar";
+  const double updateRate = 10;
+
+  gz::math::Pose3d sensorPose(gz::math::Vector3d(0.25, 0.0, 0.5),
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf(name, sensorPose, updateRate, topic,
+      640, -1.396, 1.396, 1, 0, 0, 0.08, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  EXPECT_EQ(name, sensor->Name());
+  EXPECT_EQ(topic, sensor->Topic());
+  EXPECT_DOUBLE_EQ(updateRate, sensor->UpdateRate());
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, LidarConfig)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_config", sensorPose, 10,
+      "/test/config",
+      640, -1.396, 1.396,
+      16, -0.26, 0.26,
+      0.08, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  EXPECT_EQ(640u, sensor->RayCount());
+  EXPECT_EQ(16u, sensor->VerticalRayCount());
+  EXPECT_NEAR(-1.396, sensor->AngleMin().Radian(), 1e-6);
+  EXPECT_NEAR(1.396, sensor->AngleMax().Radian(), 1e-6);
+  EXPECT_NEAR(-0.26, sensor->VerticalAngleMin().Radian(), 1e-6);
+  EXPECT_NEAR(0.26, sensor->VerticalAngleMax().Radian(), 1e-6);
+  EXPECT_DOUBLE_EQ(0.08, sensor->RangeMin());
+  EXPECT_DOUBLE_EQ(10.0, sensor->RangeMax());
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, GenerateRays)
+{
+  // 3 horizontal rays over 180° FOV, 1 vertical layer, range [0.1, 5.0]
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_rays", sensorPose, 10,
+      "/test/rays",
+      3, -GZ_PI / 2, GZ_PI / 2,
+      1, 0, 0,
+      0.1, 5.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  auto rays = sensor->GenerateRays();
+  ASSERT_EQ(3u, rays.size());
+
+  // Each ray should start at range_min and end at range_max distance
+  for (const auto &ray : rays) {
+    EXPECT_NEAR(0.1, ray.first.Length(), 1e-6);
+    EXPECT_NEAR(5.0, ray.second.Length(), 1e-6);
+  }
+
+  // Ray 0: azimuth = -π/2 → direction (0, -1, 0)
+  EXPECT_NEAR(0.0, rays[0].first.X(), 1e-4);
+  EXPECT_NEAR(-0.1, rays[0].first.Y(), 1e-4);
+  EXPECT_NEAR(0.0, rays[0].second.X(), 1e-4);
+  EXPECT_NEAR(-5.0, rays[0].second.Y(), 1e-4);
+
+  // Ray 1: azimuth = 0 → direction (1, 0, 0)
+  EXPECT_NEAR(0.1, rays[1].first.X(), 1e-6);
+  EXPECT_NEAR(0.0, rays[1].first.Y(), 1e-6);
+  EXPECT_NEAR(5.0, rays[1].second.X(), 1e-6);
+  EXPECT_NEAR(0.0, rays[1].second.Y(), 1e-6);
+
+  // Ray 2: azimuth = π/2 → direction (0, 1, 0)
+  EXPECT_NEAR(0.0, rays[2].first.X(), 1e-4);
+  EXPECT_NEAR(0.1, rays[2].first.Y(), 1e-4);
+  EXPECT_NEAR(0.0, rays[2].second.X(), 1e-4);
+  EXPECT_NEAR(5.0, rays[2].second.Y(), 1e-4);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, GenerateRaysMultiLayer)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_multi", sensorPose, 10,
+      "/test/multi",
+      4, -GZ_PI / 4, GZ_PI / 4,
+      3, -0.2, 0.2,
+      0.5, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  auto rays = sensor->GenerateRays();
+  // 4 horizontal × 3 vertical = 12 rays
+  ASSERT_EQ(12u, rays.size());
+
+  for (const auto &ray : rays) {
+    EXPECT_NEAR(0.5, ray.first.Length(), 1e-6);
+    EXPECT_NEAR(10.0, ray.second.Length(), 1e-6);
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, SetRaycastResults)
+{
+  // 3 horizontal rays, range [0.1, 5.0]
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_results", sensorPose, 10,
+      "/test/results",
+      3, -GZ_PI / 4, GZ_PI / 4,
+      1, 0, 0,
+      0.1, 5.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  auto rays = sensor->GenerateRays();
+  ASSERT_EQ(3u, rays.size());
+
+  // Build results: hit at fraction 0.5, no hit, hit at fraction 0.0
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(3);
+
+  results[0].fraction = 0.5;
+  results[0].point = rays[0].first + 0.5 * (rays[0].second - rays[0].first);
+
+  // Ray 1: no hit — +INF fraction
+  results[1].fraction = std::numeric_limits<double>::infinity();
+  results[1].point = {std::numeric_limits<double>::quiet_NaN(),
+                      std::numeric_limits<double>::quiet_NaN(),
+                      std::numeric_limits<double>::quiet_NaN()};
+
+  // Ray 2: hit very close → fraction 0.0 (at start = range_min)
+  results[2].fraction = 0.0;
+  results[2].point = rays[2].first;
+
+  sensor->SetRaycastResults(results);
+
+  std::vector<double> ranges;
+  sensor->Ranges(ranges);
+
+  ASSERT_EQ(3u, ranges.size());
+  // Ray 0: hit at midpoint between range_min and range_max
+  EXPECT_NEAR(2.55, ranges[0], 1e-4);
+  // Ray 1: no hit → +inf (REP-117)
+  EXPECT_TRUE(std::isinf(ranges[1]));
+  // Ray 2: hit at range_min
+  EXPECT_NEAR(0.1, ranges[2], 1e-4);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, PublishLaserScan)
+{
+  const std::string topic = "/test/cpu_lidar/scan";
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_pub", sensorPose, 30, topic,
+      3, -0.2, 0.2,
+      1, 0, 0,
+      0.1, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  gz::transport::Node node;
+  std::vector<gz::msgs::LaserScan> received;
+  std::mutex mtx;
+  std::function<void(const gz::msgs::LaserScan &)> cb =
+    [&](const gz::msgs::LaserScan &_msg) {
+      std::lock_guard<std::mutex> lock(mtx);
+      received.push_back(_msg);
+    };
+  auto sub = node.CreateSubscriber(topic, cb);
+
+  EXPECT_TRUE(sensor->HasConnections());
+
+  auto rays = sensor->GenerateRays();
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(3);
+  for (size_t i = 0; i < 3; ++i)
+  {
+    results[i].fraction = 0.5;
+    results[i].point = rays[i].first +
+      0.5 * (rays[i].second - rays[i].first);
+  }
+  results[0].intensity = 0.1;
+  results[1].intensity = 0.6;
+  results[2].intensity = 1.0;
+  sensor->SetRaycastResults(results);
+
+  auto now = std::chrono::steady_clock::duration(
+    std::chrono::milliseconds(100));
+  EXPECT_TRUE(sensor->Update(now));
+
+  for (int i = 0; i < 100 && received.empty(); ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  std::lock_guard<std::mutex> lock(mtx);
+  ASSERT_GE(received.size(), 1u);
+  auto &msg = received.back();
+  EXPECT_EQ(3, msg.count());
+  EXPECT_NEAR(-0.2, msg.angle_min(), 1e-4);
+  EXPECT_NEAR(0.2, msg.angle_max(), 1e-4);
+  EXPECT_DOUBLE_EQ(0.1, msg.range_min());
+  EXPECT_DOUBLE_EQ(10.0, msg.range_max());
+  ASSERT_EQ(3, msg.ranges_size());
+  for (int i = 0; i < msg.ranges_size(); ++i)
+    EXPECT_NEAR(5.05, msg.ranges(i), 1e-2);
+  ASSERT_EQ(3, msg.intensities_size());
+  EXPECT_NEAR(0.1, msg.intensities(0), 1e-6);
+  EXPECT_NEAR(0.6, msg.intensities(1), 1e-6);
+  EXPECT_NEAR(1.0, msg.intensities(2), 1e-6);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, NoiseApplied)
+{
+  gz::math::Rand::Seed(42);
+
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("noisy_lidar", sensorPose, 30,
+      "/test/cpu_lidar/noise",
+      10, -0.5, 0.5,
+      1, 0, 0,
+      0.1, 10.0, true, false,
+      1.0, 1.0,
+      "gaussian", 0.0, 0.5);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  auto rays = sensor->GenerateRays();
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    results[i].fraction = 0.5;
+    results[i].point = rays[i].first +
+      0.5 * (rays[i].second - rays[i].first);
+  }
+  sensor->SetRaycastResults(results);
+
+  std::vector<double> ranges;
+  sensor->Ranges(ranges);
+  ASSERT_EQ(10u, ranges.size());
+
+  int diffCount = 0;
+  for (size_t i = 0; i < ranges.size(); ++i)
+  {
+    if (std::abs(ranges[i] - 5.05) > 1e-6)
+      ++diffCount;
+    EXPECT_GT(ranges[i], 0.0);
+    EXPECT_LT(ranges[i], 15.0);
+  }
+  EXPECT_GT(diffCount, 0) << "Noise should perturb at least some ranges";
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, PublishPointCloud)
+{
+  const std::string topic = "/test/cpu_lidar/pc";
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_pc", sensorPose, 30, topic,
+      3, -0.2, 0.2,
+      1, 0, 0,
+      0.1, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  gz::transport::Node node;
+  std::vector<gz::msgs::PointCloudPacked> received;
+  std::mutex mtx;
+  std::function<void(const gz::msgs::PointCloudPacked &)> cb =
+    [&](const gz::msgs::PointCloudPacked &_msg) {
+      std::lock_guard<std::mutex> lock(mtx);
+      received.push_back(_msg);
+    };
+  auto sub = node.CreateSubscriber(topic + "/points", cb);
+
+  auto rays = sensor->GenerateRays();
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(3);
+  for (size_t i = 0; i < 3; ++i)
+  {
+    results[i].fraction = 0.5;
+    results[i].point = rays[i].first +
+      0.5 * (rays[i].second - rays[i].first);
+  }
+  results[0].intensity = 0.2;
+  results[1].intensity = 0.7;
+  results[2].intensity = 1.2;
+  sensor->SetRaycastResults(results);
+
+  auto now = std::chrono::steady_clock::duration(
+    std::chrono::milliseconds(100));
+  EXPECT_TRUE(sensor->Update(now));
+
+  for (int i = 0; i < 100 && received.empty(); ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  std::lock_guard<std::mutex> lock(mtx);
+  ASSERT_GE(received.size(), 1u);
+  auto &msg = received.back();
+  EXPECT_EQ(3u, msg.width());
+  EXPECT_EQ(1u, msg.height());
+  EXPECT_TRUE(msg.is_dense());
+  ASSERT_GT(msg.data().size(), 0u);
+
+  int intensityOffset = -1;
+  for (int i = 0; i < msg.field_size(); ++i)
+  {
+    if (msg.field(i).name() == "intensity")
+    {
+      intensityOffset = static_cast<int>(msg.field(i).offset());
+      break;
+    }
+  }
+  ASSERT_GE(intensityOffset, 0);
+
+  std::vector<float> publishedIntensities;
+  publishedIntensities.reserve(msg.width());
+  for (uint32_t i = 0; i < msg.width(); ++i)
+  {
+    const char *base = msg.data().data() + i * msg.point_step();
+    float intensity =
+      *reinterpret_cast<const float *>(base + intensityOffset);
+    publishedIntensities.push_back(intensity);
+  }
+  EXPECT_NEAR(0.2f, publishedIntensities[0], 1e-6);
+  EXPECT_NEAR(0.7f, publishedIntensities[1], 1e-6);
+  EXPECT_NEAR(1.2f, publishedIntensities[2], 1e-6);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, NoiseClamping)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("clamped_lidar", sensorPose, 10,
+      "/test/cpu_lidar/clamping",
+      1, 0, 0,
+      1, 0, 0,
+      0.1, 10.0, true, false,
+      1.0, 1.0,
+      "gaussian", 5.0, 0.0);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  auto rays = sensor->GenerateRays();
+  ASSERT_EQ(1u, rays.size());
+
+  // Supply a raycast result of 8.0.
+  // range = range_min + fraction * (range_max - range_min)
+  // 8.0 = 0.1 + fraction * 9.9 → fraction = 7.9 / 9.9
+  const double rangeMin = 0.1;
+  const double rangeMax = 10.0;
+  const double targetRange = 8.0;
+  const double fraction = (targetRange - rangeMin) / (rangeMax - rangeMin);
+
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(1);
+  results[0].fraction = fraction;
+  results[0].point = rays[0].first +
+    fraction * (rays[0].second - rays[0].first);
+  sensor->SetRaycastResults(results);
+
+  std::vector<double> ranges;
+  sensor->Ranges(ranges);
+  ASSERT_EQ(1u, ranges.size());
+
+  // With mean 5.0 and stddev 0.0, raw range 8.0 becomes 13.0, clamped to 10.0
+  EXPECT_NEAR(10.0, ranges[0], 1e-6);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, DefaultTopic)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+
+  // Empty topic → falls back to /lidar
+  auto sdf = CpuLidarToSdf("test_default_topic", sensorPose, 10,
+      "", 3, -0.5, 0.5, 1, 0, 0, 0.08, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+  EXPECT_EQ("/lidar", sensor->Topic());
+
+  // Custom topic is used as-is
+  auto sdf2 = CpuLidarToSdf("test_custom_topic", sensorPose, 10,
+      "/my/custom/topic", 3, -0.5, 0.5, 1, 0, 0, 0.08, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf2);
+
+  auto sensor2 = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf2);
+  ASSERT_NE(nullptr, sensor2);
+  EXPECT_EQ("/my/custom/topic", sensor2->Topic());
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, HasConnectionsFalse)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_no_conn", sensorPose, 30,
+      "/test/cpu_lidar/no_conn",
+      3, -0.5, 0.5, 1, 0, 0, 0.1, 10.0, true, false);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  // No subscribers → HasConnections is false
+  EXPECT_FALSE(sensor->HasConnections());
+
+  // Feed some results and try to update
+  auto rays = sensor->GenerateRays();
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(3);
+  for (size_t i = 0; i < 3; ++i)
+  {
+    results[i].fraction = 0.5;
+    results[i].point = rays[i].first +
+      0.5 * (rays[i].second - rays[i].first);
+  }
+  sensor->SetRaycastResults(results);
+
+  auto now = std::chrono::steady_clock::duration(
+    std::chrono::milliseconds(100));
+  EXPECT_FALSE(sensor->Update(now));
+}
+
+/////////////////////////////////////////////////
+TEST_F(CpuLidarSensorTest, NonUnitResolution)
+{
+  gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
+      gz::math::Quaterniond::Identity);
+  auto sdf = CpuLidarToSdf("test_resolution", sensorPose, 10,
+      "/test/resolution",
+      8, -GZ_PI / 4, GZ_PI / 4,
+      4, -0.1, 0.1,
+      0.1, 10.0, true, false,
+      /*_horzResolution=*/2.0, /*_vertResolution=*/0.5);
+  ASSERT_NE(nullptr, sdf);
+
+  gz::sensors::SensorFactory sf;
+  auto sensor = sf.CreateSensor<gz::sensors::CpuLidarSensor>(sdf);
+  ASSERT_NE(nullptr, sensor);
+
+  EXPECT_EQ(8u, sensor->RayCount());
+  EXPECT_EQ(4u, sensor->VerticalRayCount());
+
+  auto rays = sensor->GenerateRays();
+  ASSERT_EQ(32u, rays.size());
+
+  for (const auto &ray : rays)
+  {
+    EXPECT_NEAR(0.1, ray.first.Length(), 1e-6);
+    EXPECT_NEAR(10.0, ray.second.Length(), 1e-6);
+  }
+}

--- a/test/integration/cpu_lidar_sensor.cc
+++ b/test/integration/cpu_lidar_sensor.cc
@@ -246,12 +246,12 @@ TEST_F(CpuLidarSensorTest, GenerateRaysMultiLayer)
 /////////////////////////////////////////////////
 TEST_F(CpuLidarSensorTest, SetRaycastResults)
 {
-  // 3 horizontal rays, range [0.1, 5.0]
+  // 4 horizontal rays, range [0.1, 5.0]
   gz::math::Pose3d sensorPose(gz::math::Vector3d::Zero,
       gz::math::Quaterniond::Identity);
   auto sdf = CpuLidarToSdf("test_results", sensorPose, 10,
       "/test/results",
-      3, -GZ_PI / 4, GZ_PI / 4,
+      4, -GZ_PI / 4, GZ_PI / 4,
       1, 0, 0,
       0.1, 5.0, true, false);
   ASSERT_NE(nullptr, sdf);
@@ -261,15 +261,16 @@ TEST_F(CpuLidarSensorTest, SetRaycastResults)
   ASSERT_NE(nullptr, sensor);
 
   auto rays = sensor->GenerateRays();
-  ASSERT_EQ(3u, rays.size());
+  ASSERT_EQ(4u, rays.size());
 
-  // Build results: hit at fraction 0.5, no hit, hit at fraction 0.0
-  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(3);
+  // Build results: hit at fraction 0.5, no hit (+INF), hit at fraction 0.0,
+  // no hit (NaN)
+  std::vector<gz::sensors::CpuLidarSensor::RayResult> results(4);
 
   results[0].fraction = 0.5;
   results[0].point = rays[0].first + 0.5 * (rays[0].second - rays[0].first);
 
-  // Ray 1: no hit — +INF fraction
+  // Ray 1: no hit — +INF fraction (gz-physics10 miss convention)
   results[1].fraction = std::numeric_limits<double>::infinity();
   results[1].point = {std::numeric_limits<double>::quiet_NaN(),
                       std::numeric_limits<double>::quiet_NaN(),
@@ -279,18 +280,29 @@ TEST_F(CpuLidarSensorTest, SetRaycastResults)
   results[2].fraction = 0.0;
   results[2].point = rays[2].first;
 
+  // Ray 3: no hit — NaN fraction (gz-physics9 miss convention). The sensor
+  // must still publish +inf per REP-117, not a NaN range.
+  results[3].fraction = std::numeric_limits<double>::quiet_NaN();
+  results[3].point = {std::numeric_limits<double>::quiet_NaN(),
+                      std::numeric_limits<double>::quiet_NaN(),
+                      std::numeric_limits<double>::quiet_NaN()};
+
   sensor->SetRaycastResults(results);
 
   std::vector<double> ranges;
   sensor->Ranges(ranges);
 
-  ASSERT_EQ(3u, ranges.size());
+  ASSERT_EQ(4u, ranges.size());
   // Ray 0: hit at midpoint between range_min and range_max
   EXPECT_NEAR(2.55, ranges[0], 1e-4);
-  // Ray 1: no hit → +inf (REP-117)
+  // Ray 1: no hit (+INF fraction) → +inf (REP-117)
   EXPECT_TRUE(std::isinf(ranges[1]));
+  EXPECT_GT(ranges[1], 0.0);
   // Ray 2: hit at range_min
   EXPECT_NEAR(0.1, ranges[2], 1e-4);
+  // Ray 3: no hit (NaN fraction) → +inf (REP-117), not NaN
+  EXPECT_TRUE(std::isinf(ranges[3]));
+  EXPECT_GT(ranges[3], 0.0);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Backport of #593 (`CpuLidarSensor`) to the `gz-sensors10` LTS branch. Depends on [PR 1 (gz-physics9)](https://github.com/gazebosim/gz-physics/pull/1027).

## Summary

`CpuLidarSensor` publishes `LaserScan` and `PointCloudPacked` from raycast results with zero dependency on `gz-rendering`, so it runs headless where `GpuLidarSensor` cannot. The only change over a verbatim cherry-pick of #593 is one line, because gz-physics9 reports a miss as `NaN` while gz-physics10 reports `+INF`:

```diff
-    if (std::isinf(_results[i].fraction))
+    if (!std::isfinite(_results[i].fraction))
```

With `std::isinf`, a `NaN` miss on gz-physics9 takes the hit path and publishes a `NaN` range instead of `+inf`. `!std::isfinite` is true for both `NaN` and `+INF`, so it is correct on both.

## Backport Policy
- [x] Other (fill in yourself)

This PR is itself the Jetty backport of #593. Further backports left to maintainer discretion. Must land after PR 1.

## Test it

```bash
colcon test --packages-select gz-sensors --ctest-args -R INTEGRATION_cpu_lidar_sensor
```

12/12 (asserts `+inf`-on-miss for both a `+INF` and a `NaN` miss). Full suite 57/57. End-to-end on the Jetty stack, a 640-beam scan publishes 538 misses as `inf`, 0 `nan`, 102 hits, identical with rendering fully stripped.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial <!-- ships in PR 3 -->
- [x] Updated documentation (as needed) <!-- corrected RayResult::fraction miss doc for gz-physics9 -->
- [ ] `codecheck` passed <!-- pending run against final commits -->
- [x] All tests passed
- [x] Updated Bazel files (if adding new files). Created an issue otherwise. <!-- carried from #593 -->
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits.

Assisted-by: Claude Opus 4.8 (Anthropic Claude Code)

**Note to maintainers**: Backport, please use **Rebase and Merge**. The #593 cherry-pick keeps its original authorship and carries no AI trailer.