### PR TITLE
Prevent camera frame header accumulation

### DIFF
--- a/src/SegmentationCameraSensor.cc
+++ b/src/SegmentationCameraSensor.cc
@@ -512,6 +512,7 @@ bool SegmentationCameraSensor::Update(
   // time stamp
   auto stamp = this->dataPtr->coloredMapMsg.mutable_header()->mutable_stamp();
   *stamp = msgs::Convert(_now);
+  this->dataPtr->coloredMapMsg.mutable_header()->clear_data();
   auto frame = this->dataPtr->coloredMapMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
   frame->add_value(this->FrameId());

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -486,6 +486,7 @@ bool ThermalCameraSensor::Update(
   this->dataPtr->thermalMsg.set_pixel_format_type(msgsFormat);
   auto stamp = this->dataPtr->thermalMsg.mutable_header()->mutable_stamp();
   *stamp = msgs::Convert(_now);
+  this->dataPtr->thermalMsg.mutable_header()->clear_data();
   auto frame = this->dataPtr->thermalMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
   frame->add_value(this->FrameId());

--- a/test/integration/segmentation_camera.cc
+++ b/test/integration/segmentation_camera.cc
@@ -72,6 +72,16 @@ void OnNewSegmentationFrame(const msgs::Image &_msg)
   g_mutex.unlock();
 }
 
+void ExpectSingleFrameId(const msgs::Image &_msg,
+    const std::string &_expectedFrameId)
+{
+  ASSERT_TRUE(_msg.has_header());
+  ASSERT_EQ(1, _msg.header().data_size());
+  EXPECT_EQ("frame_id", _msg.header().data(0).key());
+  ASSERT_EQ(1, _msg.header().data(0).value_size());
+  EXPECT_EQ(_expectedFrameId, _msg.header().data(0).value(0));
+}
+
 /// \brief wait till you read the published frame
 void WaitForNewFrame(gz::sensors::Manager &_mgr)
 {
@@ -240,18 +250,34 @@ void SegmentationCameraSensorTest::ImagesWithBuiltinSDF(
   std::string topic =
     "/test/integration/SegmentationCameraPlugin_imagesWithBuiltinSDF";
   std::string infoTopic = topic + "/camera_info";
+  std::string coloredMapTopic = topic + "/colored_map";
   // Get the topic of the labels map
-  // TODO(anyone) add test coverage for the colored map topic and its data
+  // TODO(anyone) add test coverage for the colored map image data
   topic += "/labels_map";
 
   WaitForMessageTestHelper<gz::msgs::Image> helper(topic);
   EXPECT_TRUE(sensor->HasConnections());
+  WaitForMessageTestHelper<gz::msgs::Image> coloredMapHelper(coloredMapTopic);
   WaitForMessageTestHelper<gz::msgs::CameraInfo> infoHelper(infoTopic);
 
   // Update once to create image
   mgr.RunOnce(std::chrono::steady_clock::duration::zero());
 
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
+  EXPECT_TRUE(coloredMapHelper.WaitForMessage()) << coloredMapHelper;
+
+  const std::string originalFrameId = sensor->FrameId();
+  for (int frame = 0; frame < 3; ++frame)
+  {
+    const std::string frameId = "segmentation_frame_" + std::to_string(frame);
+    sensor->SetFrameId(frameId);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    ASSERT_TRUE(coloredMapHelper.WaitForMessage()) << coloredMapHelper;
+    ASSERT_TRUE(helper.WaitForMessage()) << helper;
+    ExpectSingleFrameId(coloredMapHelper.Message(), frameId);
+    ExpectSingleFrameId(helper.Message(), frameId);
+  }
+  sensor->SetFrameId(originalFrameId);
 
   // subscribe to the segmentation camera topic
   gz::transport::Node node;

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -87,6 +87,16 @@ void OnImage8Bit(const gz::msgs::Image &_msg)
   g_mutex.unlock();
 }
 
+void ExpectSingleFrameId(const gz::msgs::Image &_msg,
+    const std::string &_expectedFrameId)
+{
+  ASSERT_TRUE(_msg.has_header());
+  ASSERT_EQ(1, _msg.header().data_size());
+  EXPECT_EQ("frame_id", _msg.header().data(0).key());
+  ASSERT_EQ(1, _msg.header().data(0).value_size());
+  EXPECT_EQ(_expectedFrameId, _msg.header().data(0).value(0));
+}
+
 class ThermalCameraSensorTest: public testing::Test,
   public testing::WithParamInterface<const char *>
 {
@@ -215,6 +225,17 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
 
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
   EXPECT_TRUE(infoHelper.WaitForMessage()) << infoHelper;
+
+  const std::string originalFrameId = thermalSensor->FrameId();
+  for (int frame = 0; frame < 3; ++frame)
+  {
+    const std::string frameId = "thermal_frame_" + std::to_string(frame);
+    thermalSensor->SetFrameId(frameId);
+    mgr.RunOnce(std::chrono::steady_clock::duration::zero(), true);
+    ASSERT_TRUE(helper.WaitForMessage()) << helper;
+    ExpectSingleFrameId(helper.Message(), frameId);
+  }
+  thermalSensor->SetFrameId(originalFrameId);
 
   // subscribe to the thermal camera topic
   gz::transport::Node node;


### PR DESCRIPTION
## Summary

- clear the reused thermal and segmentation image-header `data` fields before
  adding the current `frame_id`
- verify three successive frame IDs never accumulate in thermal images,
  segmentation colored maps, or segmentation label maps
- preserve the existing stamp, image payload, and publish flow

The segmentation label message copies the corrected colored-map message, so
both published outputs now carry exactly one current `frame_id` entry.

Closes #638.

## Regression proof

With the new tests but without the two `clear_data()` calls, both integrations
fail: thermal, colored-map, and label-map header sizes grow from 2 to 3 to 4.
Restoring the fix makes both targeted Ogre2/Xvfb integrations pass.

## Validation

- official-action-equivalent Ubuntu Noble / Rotary dependency environment
- complete build
- cpplint and cppcheck
- full CTest suite: 57/57 passed
- restored targeted camera integrations: 2/2 passed

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)
