### PR TITLE
Reject invalid camera clip plane ordering

### DIFF
--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -231,6 +231,15 @@ Sensor::~Sensor() = default;
 //////////////////////////////////////////////////
 bool Sensor::Load(const sdf::Sensor &_sdf)
 {
+  const auto camera = _sdf.CameraSensor();
+  if (camera && !(camera->NearClip() < camera->FarClip()))
+  {
+    gzerr << "Invalid camera clip planes for sensor [" << _sdf.Name()
+           << "]: near [" << camera->NearClip() << "] must be less than far ["
+           << camera->FarClip() << "]." << std::endl;
+    return false;
+  }
+
   const bool success = this->dataPtr->PopulateFromSDF(_sdf);
   if (!success)
     return false;

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -149,6 +149,36 @@ TEST(Sensor_TEST, Topic)
   EXPECT_FALSE(sensor.SetTopic(""));
 }
 
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, CameraClipPlanes)
+{
+  sdf::Camera camera;
+  camera.SetNearClip(0.1);
+  camera.SetFarClip(10.0);
+
+  sdf::Sensor sdfSensor;
+  sdfSensor.SetName("valid_camera");
+  sdfSensor.SetType(sdf::SensorType::DEPTH_CAMERA);
+  sdfSensor.SetCameraSensor(camera);
+
+  TestSensor validSensor;
+  EXPECT_TRUE(validSensor.Load(sdfSensor));
+
+  camera.SetNearClip(1e308);
+  sdfSensor.SetName("invalid_camera");
+  sdfSensor.SetCameraSensor(camera);
+
+  TestSensor invalidSensor;
+  EXPECT_FALSE(invalidSensor.Load(sdfSensor));
+
+  camera.SetNearClip(10.0);
+  sdfSensor.SetName("equal_camera");
+  sdfSensor.SetCameraSensor(camera);
+
+  TestSensor equalSensor;
+  EXPECT_FALSE(equalSensor.Load(sdfSensor));
+}
+
 class SensorUpdate : public ::testing::Test
 {
   // Documentation inherited


### PR DESCRIPTION
## Summary

- reject camera configurations whose near clip plane is equal to or farther
  than the far clip plane before sensor initialization
- apply the check in the shared sensor load path so it covers all camera
  sensor implementations
- cover valid ordering, the reported `1e308` / `10.0` values, and equal clip
  planes

This prevents invalid clip values from reaching rendering backends and turns
the reported process abort into an ordinary sensor-load error.

Closes #584.

## Regression proof

The attached issue world reproduces the current binary behavior on Ubuntu
Noble / Gazebo Rotary: `gz sdf -k` reports it as valid, while
`gz sim -r -s` aborts in `Ogre::AxisAlignedBox` with exit 134.

With the new regression but without the validation guard, both invalid cases
load successfully and the test fails. Restoring the guard rejects both cases
with a descriptive error while preserving the valid case.

## Validation

- Ubuntu Noble / Gazebo Rotary dependency environment
- complete build
- full CTest suite: 57/57 passed
- cpplint and cppcheck
- focused regression negative control: failed as expected
- focused regression with the fix: passed

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-20)
